### PR TITLE
Change order of CallOptions in return of pool.conn

### DIFF
--- a/pkg/pool/pool.go
+++ b/pkg/pool/pool.go
@@ -218,7 +218,7 @@ func (p *pool) conn(option []client.CallOption) (client.Client, []client.CallOpt
 	if err != nil {
 		return nil, nil, err
 	}
-	return conn, append(option, client.WithSession(token)), nil
+	return conn, append([]client.CallOption{client.WithSession(token)}, option...), nil
 }
 
 func (p *pool) PutObject(ctx context.Context, params *client.PutObjectParams, option ...client.CallOption) (*object.ID, error) {


### PR DESCRIPTION
Moved WithSession with session token got from pool.Connection
to the top of returned slice because it overlaps WithSession in
'option' parameter

Signed-off-by: Angira Kekteeva <kira@nspcc.ru>