### PR TITLE
pool: Do not invoke EndpointInfo to find the address

### DIFF
--- a/pool/pool.go
+++ b/pool/pool.go
@@ -13,7 +13,6 @@ import (
 	"github.com/nspcc-dev/neofs-api-go/pkg/client"
 	"github.com/nspcc-dev/neofs-api-go/pkg/container"
 	cid "github.com/nspcc-dev/neofs-api-go/pkg/container/id"
-	"github.com/nspcc-dev/neofs-api-go/pkg/netmap"
 	"github.com/nspcc-dev/neofs-api-go/pkg/object"
 	"github.com/nspcc-dev/neofs-api-go/pkg/owner"
 	"github.com/nspcc-dev/neofs-api-go/pkg/session"
@@ -115,20 +114,6 @@ func newPool(ctx context.Context, options *BuilderOptions) (Pool, error) {
 		}
 		st, err := c.CreateSession(ctx, options.SessionExpirationEpoch)
 		if err != nil {
-			var address interface{} = "unknown"
-
-			if epi, err := c.EndpointInfo(ctx); err == nil {
-				ni := epi.NodeInfo()
-
-				addresses := make([]string, 0, ni.NumberOfAddresses())
-
-				netmap.IterateAllAddresses(ni, func(addr string) {
-					addresses = append(addresses, addr)
-				})
-
-				address = addresses
-			}
-
 			return nil, fmt.Errorf("failed to create neofs session token for client %v: %w", address, err)
 		}
 		clientPacks[i] = &clientPack{client: c, sessionToken: st, healthy: true}


### PR DESCRIPTION
Since we transformed the pool of gRPC connection into the pool of neofs clients (see https://github.com/nspcc-dev/neofs-sdk-go/commit/10284ddd63ae734b191a2faad592c199b31660c8#), we don't need to call `EndpointInfo` to fetch the address of the node for the beautiful error output.

Moreover it is done incorrectly, because `c.CreateSession` may return `context.Cancelled` error (graceful shutdown). We will reuse the same context for the `EndpointInfo` call which will lead to a timeout freeze.