### PR TITLE
Move decimal structure to SDK

### DIFF
--- a/accounting/decimal.go
+++ b/accounting/decimal.go
@@ -1,0 +1,69 @@
+package accounting
+
+import "github.com/nspcc-dev/neofs-api-go/v2/accounting"
+
+// Decimal represents decimal number for accounting operations.
+type Decimal accounting.Decimal
+
+// NewDecimal creates, initializes and returns empty Decimal instance.
+//
+// Defaults:
+//  - value: 0
+//  - precision: 0
+func NewDecimal() *Decimal {
+	return NewDecimalFromV2(new(accounting.Decimal))
+}
+
+// NewDecimalFromV2 converts v2 Decimal to Decimal.
+//
+// Nil Decimal converts to nil.
+func NewDecimalFromV2(d *accounting.Decimal) *Decimal {
+	return (*Decimal)(d)
+}
+
+// ToV2 returns the v2 Decimal message.
+//
+// Nil Decimal converts to nil.
+func (d *Decimal) ToV2() *accounting.Decimal {
+	return (*accounting.Decimal)(d)
+}
+
+// Value returns value of the decimal number.
+func (d *Decimal) Value() int64 {
+	return (*accounting.Decimal)(d).GetValue()
+}
+
+// SetValue sets value of the decimal number.
+func (d *Decimal) SetValue(v int64) {
+	(*accounting.Decimal)(d).SetValue(v)
+}
+
+// Precision returns precision of the decimal number.
+func (d *Decimal) Precision() uint32 {
+	return (*accounting.Decimal)(d).GetPrecision()
+}
+
+// SetPrecision sets precision of the decimal number.
+func (d *Decimal) SetPrecision(p uint32) {
+	(*accounting.Decimal)(d).SetPrecision(p)
+}
+
+// Marshal marshals Decimal into a protobuf binary form.
+func (d *Decimal) Marshal() ([]byte, error) {
+	return (*accounting.Decimal)(d).StableMarshal(nil)
+}
+
+// Unmarshal unmarshalls protobuf binary representation of Decimal.
+func (d *Decimal) Unmarshal(data []byte) error {
+	return (*accounting.Decimal)(d).Unmarshal(data)
+}
+
+// MarshalJSON encodes Decimal to protobuf JSON format.
+func (d *Decimal) MarshalJSON() ([]byte, error) {
+	return (*accounting.Decimal)(d).MarshalJSON()
+}
+
+// UnmarshalJSON decodes Decimal from protobuf JSON format.
+func (d *Decimal) UnmarshalJSON(data []byte) error {
+	return (*accounting.Decimal)(d).UnmarshalJSON(data)
+}

--- a/accounting/decimal_test.go
+++ b/accounting/decimal_test.go
@@ -1,0 +1,44 @@
+package accounting_test
+
+import (
+	"testing"
+
+	"github.com/nspcc-dev/neofs-sdk-go/accounting"
+	test "github.com/nspcc-dev/neofs-sdk-go/accounting/test"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecimal(t *testing.T) {
+	const v, p = 4, 2
+
+	d := accounting.NewDecimal()
+	d.SetValue(v)
+	d.SetPrecision(p)
+
+	require.EqualValues(t, v, d.Value())
+	require.EqualValues(t, p, d.Precision())
+}
+
+func TestDecimalEncoding(t *testing.T) {
+	d := test.GenerateDecimal()
+
+	t.Run("binary", func(t *testing.T) {
+		data, err := d.Marshal()
+		require.NoError(t, err)
+
+		d2 := accounting.NewDecimal()
+		require.NoError(t, d2.Unmarshal(data))
+
+		require.Equal(t, d, d2)
+	})
+
+	t.Run("json", func(t *testing.T) {
+		data, err := d.MarshalJSON()
+		require.NoError(t, err)
+
+		d2 := accounting.NewDecimal()
+		require.NoError(t, d2.UnmarshalJSON(data))
+
+		require.Equal(t, d, d2)
+	})
+}

--- a/accounting/test/decimal.go
+++ b/accounting/test/decimal.go
@@ -1,0 +1,16 @@
+package accountingtest
+
+import (
+	"math/rand"
+
+	"github.com/nspcc-dev/neofs-sdk-go/accounting"
+)
+
+// GenerateDecimal returns random accounting.Decimal.
+func GenerateDecimal() *accounting.Decimal {
+	d := accounting.NewDecimal()
+	d.SetValue(rand.Int63())
+	d.SetPrecision(rand.Uint32())
+
+	return d
+}


### PR DESCRIPTION
Closes #39 

Changes from neofs-api-go:
- `Marshal(... []byte) []byte` -> `Marhshal() []byte`
- `Generate()` -> `GenerateDecimal()`
- `GenerateDecimal()` uses random generator
- Reordered tests a bit