### PR TITLE
container: move id from neofs-api-go

### DIFF
--- a/container/id/id.go
+++ b/container/id/id.go
@@ -1,0 +1,90 @@
+package cid
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"errors"
+
+	"github.com/mr-tron/base58"
+	"github.com/nspcc-dev/neofs-api-go/v2/refs"
+)
+
+// ID represents v2-compatible container identifier.
+type ID refs.ContainerID
+
+// NewFromV2 wraps v2 ContainerID message to ID.
+//
+// Nil refs.ContainerID converts to nil.
+func NewFromV2(idV2 *refs.ContainerID) *ID {
+	return (*ID)(idV2)
+}
+
+// New creates and initializes blank ID.
+//
+// Defaults:
+//  - value: nil.
+func New() *ID {
+	return NewFromV2(new(refs.ContainerID))
+}
+
+// SetSHA256 sets container identifier value to SHA256 checksum of container body.
+func (id *ID) SetSHA256(v [sha256.Size]byte) {
+	(*refs.ContainerID)(id).SetValue(v[:])
+}
+
+// ToV2 returns the v2 container ID message.
+//
+// Nil ID converts to nil.
+func (id *ID) ToV2() *refs.ContainerID {
+	return (*refs.ContainerID)(id)
+}
+
+// Equal returns true if identifiers are identical.
+func (id *ID) Equal(id2 *ID) bool {
+	return bytes.Equal(
+		(*refs.ContainerID)(id).GetValue(),
+		(*refs.ContainerID)(id2).GetValue(),
+	)
+}
+
+// Parse parses string representation of ID.
+//
+// Returns error if s is not a base58 encoded
+// ID data.
+func (id *ID) Parse(s string) error {
+	data, err := base58.Decode(s)
+	if err != nil {
+		return err
+	} else if len(data) != sha256.Size {
+		return errors.New("incorrect format of the string container ID")
+	}
+
+	(*refs.ContainerID)(id).SetValue(data)
+
+	return nil
+}
+
+// String returns base58 string representation of ID.
+func (id *ID) String() string {
+	return base58.Encode((*refs.ContainerID)(id).GetValue())
+}
+
+// Marshal marshals ID into a protobuf binary form.
+func (id *ID) Marshal() ([]byte, error) {
+	return (*refs.ContainerID)(id).StableMarshal(nil)
+}
+
+// Unmarshal unmarshals protobuf binary representation of ID.
+func (id *ID) Unmarshal(data []byte) error {
+	return (*refs.ContainerID)(id).Unmarshal(data)
+}
+
+// MarshalJSON encodes ID to protobuf JSON format.
+func (id *ID) MarshalJSON() ([]byte, error) {
+	return (*refs.ContainerID)(id).MarshalJSON()
+}
+
+// UnmarshalJSON decodes ID from protobuf JSON format.
+func (id *ID) UnmarshalJSON(data []byte) error {
+	return (*refs.ContainerID)(id).UnmarshalJSON(data)
+}

--- a/container/id/id_test.go
+++ b/container/id/id_test.go
@@ -1,0 +1,105 @@
+package cid_test
+
+import (
+	"crypto/sha256"
+	"math/rand"
+	"testing"
+
+	"github.com/nspcc-dev/neofs-api-go/v2/refs"
+	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
+	cidtest "github.com/nspcc-dev/neofs-sdk-go/container/id/test"
+	"github.com/stretchr/testify/require"
+)
+
+func randSHA256Checksum() (cs [sha256.Size]byte) {
+	rand.Read(cs[:])
+	return
+}
+
+func TestID_ToV2(t *testing.T) {
+	t.Run("non-nil", func(t *testing.T) {
+		checksum := randSHA256Checksum()
+
+		id := cidtest.GenerateIDWithChecksum(checksum)
+
+		idV2 := id.ToV2()
+
+		require.Equal(t, id, cid.NewFromV2(idV2))
+		require.Equal(t, checksum[:], idV2.GetValue())
+	})
+
+	t.Run("nil", func(t *testing.T) {
+		var x *cid.ID
+
+		require.Nil(t, x.ToV2())
+	})
+
+	t.Run("default values", func(t *testing.T) {
+		id := cid.New()
+
+		// convert to v2 message
+		cidV2 := id.ToV2()
+		require.Nil(t, cidV2.GetValue())
+	})
+}
+
+func TestID_Equal(t *testing.T) {
+	cs := randSHA256Checksum()
+
+	id1 := cidtest.GenerateIDWithChecksum(cs)
+	id2 := cidtest.GenerateIDWithChecksum(cs)
+
+	require.True(t, id1.Equal(id2))
+
+	id3 := cidtest.GenerateID()
+
+	require.False(t, id1.Equal(id3))
+}
+
+func TestID_String(t *testing.T) {
+	t.Run("Parse/String", func(t *testing.T) {
+		id := cidtest.GenerateID()
+		id2 := cid.New()
+
+		require.NoError(t, id2.Parse(id.String()))
+		require.Equal(t, id, id2)
+	})
+
+	t.Run("nil", func(t *testing.T) {
+		id := cid.New()
+
+		require.Empty(t, id.String())
+	})
+}
+
+func TestContainerIDEncoding(t *testing.T) {
+	id := cidtest.GenerateID()
+
+	t.Run("binary", func(t *testing.T) {
+		data, err := id.Marshal()
+		require.NoError(t, err)
+
+		id2 := cid.New()
+		require.NoError(t, id2.Unmarshal(data))
+
+		require.Equal(t, id, id2)
+	})
+
+	t.Run("json", func(t *testing.T) {
+		data, err := id.MarshalJSON()
+		require.NoError(t, err)
+
+		a2 := cid.New()
+		require.NoError(t, a2.UnmarshalJSON(data))
+
+		require.Equal(t, id, a2)
+	})
+}
+
+func TestNewFromV2(t *testing.T) {
+	t.Run("from nil", func(t *testing.T) {
+		var x *refs.ContainerID
+
+		require.Nil(t, cid.NewFromV2(x))
+	})
+}

--- a/container/id/test/id.go
+++ b/container/id/test/id.go
@@ -1,0 +1,26 @@
+package cidtest
+
+import (
+	"crypto/sha256"
+	"math/rand"
+
+	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
+)
+
+// GenerateID returns random cid.ID.
+func GenerateID() *cid.ID {
+	checksum := [sha256.Size]byte{}
+
+	rand.Read(checksum[:])
+
+	return GenerateIDWithChecksum(checksum)
+}
+
+// GenerateIDWithChecksum returns cid.ID initialized
+// with specified checksum.
+func GenerateIDWithChecksum(cs [sha256.Size]byte) *cid.ID {
+	id := cid.New()
+	id.SetSHA256(cs)
+
+	return id
+}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20210521073959-f0d4d129b7f1
 	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.2.0
+	github.com/mr-tron/base58 v1.2.0
 	github.com/nspcc-dev/hrw v1.0.9
 	github.com/nspcc-dev/neo-go v0.96.1
 	github.com/nspcc-dev/neofs-api-go v1.30.0


### PR DESCRIPTION
Change `Marshal` signature to `Marshal() ([]byte, error)`.
Dependency update in SDK itself should be done after moving client
as `pool` package has some dependent function signatures.

Signed-off-by: Evgenii Stratonikov <evgeniy@nspcc.ru>