### PR TITLE
Feat/Improve UX

### DIFF
--- a/audit/result.go
+++ b/audit/result.go
@@ -4,7 +4,7 @@ import (
 	"github.com/nspcc-dev/neofs-api-go/v2/audit"
 	"github.com/nspcc-dev/neofs-api-go/v2/refs"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
-	"github.com/nspcc-dev/neofs-sdk-go/object"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"github.com/nspcc-dev/neofs-sdk-go/version"
 )
 
@@ -141,7 +141,7 @@ func (r *Result) SetRetries(v uint32) {
 }
 
 // PassSG returns list of Storage Groups that passed audit PoR stage.
-func (r *Result) PassSG() []*object.ID {
+func (r *Result) PassSG() []*oid.ID {
 	mV2 := (*audit.DataAuditResult)(r).
 		GetPassSG()
 
@@ -149,17 +149,17 @@ func (r *Result) PassSG() []*object.ID {
 		return nil
 	}
 
-	m := make([]*object.ID, len(mV2))
+	m := make([]*oid.ID, len(mV2))
 
 	for i := range mV2 {
-		m[i] = object.NewIDFromV2(mV2[i])
+		m[i] = oid.NewIDFromV2(mV2[i])
 	}
 
 	return m
 }
 
 // SetPassSG sets list of Storage Groups that passed audit PoR stage.
-func (r *Result) SetPassSG(list []*object.ID) {
+func (r *Result) SetPassSG(list []*oid.ID) {
 	mV2 := (*audit.DataAuditResult)(r).
 		GetPassSG()
 
@@ -183,7 +183,7 @@ func (r *Result) SetPassSG(list []*object.ID) {
 }
 
 // FailSG returns list of Storage Groups that failed audit PoR stage.
-func (r *Result) FailSG() []*object.ID {
+func (r *Result) FailSG() []*oid.ID {
 	mV2 := (*audit.DataAuditResult)(r).
 		GetFailSG()
 
@@ -191,17 +191,17 @@ func (r *Result) FailSG() []*object.ID {
 		return nil
 	}
 
-	m := make([]*object.ID, len(mV2))
+	m := make([]*oid.ID, len(mV2))
 
 	for i := range mV2 {
-		m[i] = object.NewIDFromV2(mV2[i])
+		m[i] = oid.NewIDFromV2(mV2[i])
 	}
 
 	return m
 }
 
 // SetFailSG sets list of Storage Groups that failed audit PoR stage.
-func (r *Result) SetFailSG(list []*object.ID) {
+func (r *Result) SetFailSG(list []*oid.ID) {
 	mV2 := (*audit.DataAuditResult)(r).
 		GetFailSG()
 

--- a/audit/result_test.go
+++ b/audit/result_test.go
@@ -8,7 +8,7 @@ import (
 	audittest "github.com/nspcc-dev/neofs-sdk-go/audit/test"
 	cidtest "github.com/nspcc-dev/neofs-sdk-go/container/id/test"
 	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
-	"github.com/nspcc-dev/neofs-sdk-go/object/id/test"
+	oidtest "github.com/nspcc-dev/neofs-sdk-go/object/id/test"
 	"github.com/nspcc-dev/neofs-sdk-go/version"
 	"github.com/stretchr/testify/require"
 )
@@ -40,11 +40,11 @@ func TestResult(t *testing.T) {
 	r.SetRetries(retries)
 	require.Equal(t, retries, r.Retries())
 
-	passSG := []*oid.ID{test.ID(), test.ID()}
+	passSG := []*oid.ID{oidtest.ID(), oidtest.ID()}
 	r.SetPassSG(passSG)
 	require.Equal(t, passSG, r.PassSG())
 
-	failSG := []*oid.ID{test.ID(), test.ID()}
+	failSG := []*oid.ID{oidtest.ID(), oidtest.ID()}
 	r.SetFailSG(failSG)
 	require.Equal(t, failSG, r.FailSG())
 

--- a/audit/result_test.go
+++ b/audit/result_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/nspcc-dev/neofs-sdk-go/audit"
 	audittest "github.com/nspcc-dev/neofs-sdk-go/audit/test"
 	cidtest "github.com/nspcc-dev/neofs-sdk-go/container/id/test"
-	"github.com/nspcc-dev/neofs-sdk-go/object"
-	objecttest "github.com/nspcc-dev/neofs-sdk-go/object/test"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
+	"github.com/nspcc-dev/neofs-sdk-go/object/id/test"
 	"github.com/nspcc-dev/neofs-sdk-go/version"
 	"github.com/stretchr/testify/require"
 )
@@ -40,11 +40,11 @@ func TestResult(t *testing.T) {
 	r.SetRetries(retries)
 	require.Equal(t, retries, r.Retries())
 
-	passSG := []*object.ID{objecttest.ID(), objecttest.ID()}
+	passSG := []*oid.ID{test.ID(), test.ID()}
 	r.SetPassSG(passSG)
 	require.Equal(t, passSG, r.PassSG())
 
-	failSG := []*object.ID{objecttest.ID(), objecttest.ID()}
+	failSG := []*oid.ID{test.ID(), test.ID()}
 	r.SetFailSG(failSG)
 	require.Equal(t, failSG, r.FailSG())
 

--- a/audit/test/generate.go
+++ b/audit/test/generate.go
@@ -3,8 +3,8 @@ package audittest
 import (
 	"github.com/nspcc-dev/neofs-sdk-go/audit"
 	cidtest "github.com/nspcc-dev/neofs-sdk-go/container/id/test"
-	"github.com/nspcc-dev/neofs-sdk-go/object"
-	objecttest "github.com/nspcc-dev/neofs-sdk-go/object/test"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
+	"github.com/nspcc-dev/neofs-sdk-go/object/id/test"
 	versiontest "github.com/nspcc-dev/neofs-sdk-go/version/test"
 )
 
@@ -30,8 +30,8 @@ func Result() *audit.Result {
 		[]byte("node3"),
 		[]byte("node4"),
 	})
-	x.SetPassSG([]*object.ID{objecttest.ID(), objecttest.ID()})
-	x.SetFailSG([]*object.ID{objecttest.ID(), objecttest.ID()})
+	x.SetPassSG([]*oid.ID{test.ID(), test.ID()})
+	x.SetFailSG([]*oid.ID{test.ID(), test.ID()})
 
 	return x
 }

--- a/audit/test/generate.go
+++ b/audit/test/generate.go
@@ -4,7 +4,7 @@ import (
 	"github.com/nspcc-dev/neofs-sdk-go/audit"
 	cidtest "github.com/nspcc-dev/neofs-sdk-go/container/id/test"
 	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
-	"github.com/nspcc-dev/neofs-sdk-go/object/id/test"
+	oidtest "github.com/nspcc-dev/neofs-sdk-go/object/id/test"
 	versiontest "github.com/nspcc-dev/neofs-sdk-go/version/test"
 )
 
@@ -30,8 +30,8 @@ func Result() *audit.Result {
 		[]byte("node3"),
 		[]byte("node4"),
 	})
-	x.SetPassSG([]*oid.ID{test.ID(), test.ID()})
-	x.SetFailSG([]*oid.ID{test.ID(), test.ID()})
+	x.SetPassSG([]*oid.ID{oidtest.ID(), oidtest.ID()})
+	x.SetFailSG([]*oid.ID{oidtest.ID(), oidtest.ID()})
 
 	return x
 }

--- a/client/object.go
+++ b/client/object.go
@@ -17,6 +17,8 @@ import (
 	apistatus "github.com/nspcc-dev/neofs-sdk-go/client/status"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
+	"github.com/nspcc-dev/neofs-sdk-go/object/address"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	signer "github.com/nspcc-dev/neofs-sdk-go/util/signature"
 )
 
@@ -29,17 +31,17 @@ type PutObjectParams struct {
 // ObjectAddressWriter is an interface of the
 // component that writes the object address.
 type ObjectAddressWriter interface {
-	SetAddress(*object.Address)
+	SetAddress(*address.Address)
 }
 
 type DeleteObjectParams struct {
-	addr *object.Address
+	addr *address.Address
 
 	tombTgt ObjectAddressWriter
 }
 
 type GetObjectParams struct {
-	addr *object.Address
+	addr *address.Address
 
 	raw bool
 
@@ -49,7 +51,7 @@ type GetObjectParams struct {
 }
 
 type ObjectHeaderParams struct {
-	addr *object.Address
+	addr *address.Address
 
 	raw bool
 
@@ -57,7 +59,7 @@ type ObjectHeaderParams struct {
 }
 
 type RangeDataParams struct {
-	addr *object.Address
+	addr *address.Address
 
 	raw bool
 
@@ -69,7 +71,7 @@ type RangeDataParams struct {
 type RangeChecksumParams struct {
 	tz bool
 
-	addr *object.Address
+	addr *address.Address
 
 	rs []*object.Range
 
@@ -186,14 +188,14 @@ func (p *PutObjectParams) PayloadReader() io.Reader {
 type ObjectPutRes struct {
 	statusRes
 
-	id *object.ID
+	id *oid.ID
 }
 
-func (x *ObjectPutRes) setID(id *object.ID) {
+func (x *ObjectPutRes) setID(id *oid.ID) {
 	x.id = id
 }
 
-func (x ObjectPutRes) ID() *object.ID {
+func (x ObjectPutRes) ID() *oid.ID {
 	return x.id
 }
 
@@ -317,14 +319,14 @@ func (c *Client) PutObject(ctx context.Context, p *PutObjectParams, opts ...Call
 	}
 
 	// convert object identifier
-	id := object.NewIDFromV2(resp.GetBody().GetObjectID())
+	id := oid.NewIDFromV2(resp.GetBody().GetObjectID())
 
 	res.setID(id)
 
 	return res, nil
 }
 
-func (p *DeleteObjectParams) WithAddress(v *object.Address) *DeleteObjectParams {
+func (p *DeleteObjectParams) WithAddress(v *address.Address) *DeleteObjectParams {
 	if p != nil {
 		p.addr = v
 	}
@@ -332,7 +334,7 @@ func (p *DeleteObjectParams) WithAddress(v *object.Address) *DeleteObjectParams 
 	return p
 }
 
-func (p *DeleteObjectParams) Address() *object.Address {
+func (p *DeleteObjectParams) Address() *address.Address {
 	if p != nil {
 		return p.addr
 	}
@@ -361,14 +363,14 @@ func (p *DeleteObjectParams) TombstoneAddressTarget() ObjectAddressWriter {
 type ObjectDeleteRes struct {
 	statusRes
 
-	tombAddr *object.Address
+	tombAddr *address.Address
 }
 
-func (x ObjectDeleteRes) TombstoneAddress() *object.Address {
+func (x ObjectDeleteRes) TombstoneAddress() *address.Address {
 	return x.tombAddr
 }
 
-func (x *ObjectDeleteRes) setTombstoneAddress(addr *object.Address) {
+func (x *ObjectDeleteRes) setTombstoneAddress(addr *address.Address) {
 	x.tombAddr = addr
 }
 
@@ -444,12 +446,12 @@ func (c *Client) DeleteObject(ctx context.Context, p *DeleteObjectParams, opts .
 
 	addrv2 := resp.GetBody().GetTombstone()
 
-	res.setTombstoneAddress(object.NewAddressFromV2(addrv2))
+	res.setTombstoneAddress(address.NewAddressFromV2(addrv2))
 
 	return res, nil
 }
 
-func (p *GetObjectParams) WithAddress(v *object.Address) *GetObjectParams {
+func (p *GetObjectParams) WithAddress(v *address.Address) *GetObjectParams {
 	if p != nil {
 		p.addr = v
 	}
@@ -457,7 +459,7 @@ func (p *GetObjectParams) WithAddress(v *object.Address) *GetObjectParams {
 	return p
 }
 
-func (p *GetObjectParams) Address() *object.Address {
+func (p *GetObjectParams) Address() *address.Address {
 	if p != nil {
 		return p.addr
 	}
@@ -753,7 +755,7 @@ loop:
 	return res, nil
 }
 
-func (p *ObjectHeaderParams) WithAddress(v *object.Address) *ObjectHeaderParams {
+func (p *ObjectHeaderParams) WithAddress(v *address.Address) *ObjectHeaderParams {
 	if p != nil {
 		p.addr = v
 	}
@@ -761,7 +763,7 @@ func (p *ObjectHeaderParams) WithAddress(v *object.Address) *ObjectHeaderParams 
 	return p
 }
 
-func (p *ObjectHeaderParams) Address() *object.Address {
+func (p *ObjectHeaderParams) Address() *address.Address {
 	if p != nil {
 		return p.addr
 	}
@@ -937,7 +939,7 @@ func (c *Client) HeadObject(ctx context.Context, p *ObjectHeaderParams, opts ...
 	return res, nil
 }
 
-func (p *RangeDataParams) WithAddress(v *object.Address) *RangeDataParams {
+func (p *RangeDataParams) WithAddress(v *address.Address) *RangeDataParams {
 	if p != nil {
 		p.addr = v
 	}
@@ -945,7 +947,7 @@ func (p *RangeDataParams) WithAddress(v *object.Address) *RangeDataParams {
 	return p
 }
 
-func (p *RangeDataParams) Address() *object.Address {
+func (p *RangeDataParams) Address() *address.Address {
 	if p != nil {
 		return p.addr
 	}
@@ -1141,7 +1143,7 @@ func (c *Client) ObjectPayloadRangeData(ctx context.Context, p *RangeDataParams,
 	return res, nil
 }
 
-func (p *RangeChecksumParams) WithAddress(v *object.Address) *RangeChecksumParams {
+func (p *RangeChecksumParams) WithAddress(v *address.Address) *RangeChecksumParams {
 	if p != nil {
 		p.addr = v
 	}
@@ -1149,7 +1151,7 @@ func (p *RangeChecksumParams) WithAddress(v *object.Address) *RangeChecksumParam
 	return p
 }
 
-func (p *RangeChecksumParams) Address() *object.Address {
+func (p *RangeChecksumParams) Address() *address.Address {
 	if p != nil {
 		return p.addr
 	}
@@ -1329,14 +1331,14 @@ func (p *SearchObjectParams) SearchFilters() object.SearchFilters {
 type ObjectSearchRes struct {
 	statusRes
 
-	ids []*object.ID
+	ids []*oid.ID
 }
 
-func (x *ObjectSearchRes) setIDList(v []*object.ID) {
+func (x *ObjectSearchRes) setIDList(v []*oid.ID) {
 	x.ids = v
 }
 
-func (x ObjectSearchRes) IDList() []*object.ID {
+func (x ObjectSearchRes) IDList() []*oid.ID {
 	return x.ids
 }
 
@@ -1394,7 +1396,7 @@ func (c *Client) SearchObjects(ctx context.Context, p *SearchObjectParams, opts 
 	}
 
 	var (
-		searchResult []*object.ID
+		searchResult []*oid.ID
 		resp         = new(v2object.SearchResponse)
 
 		messageWas bool
@@ -1437,7 +1439,7 @@ func (c *Client) SearchObjects(ctx context.Context, p *SearchObjectParams, opts 
 
 		chunk := resp.GetBody().GetIDList()
 		for i := range chunk {
-			searchResult = append(searchResult, object.NewIDFromV2(chunk[i]))
+			searchResult = append(searchResult, oid.NewIDFromV2(chunk[i]))
 		}
 	}
 

--- a/eacl/record.go
+++ b/eacl/record.go
@@ -8,6 +8,7 @@ import (
 	"github.com/nspcc-dev/neofs-sdk-go/checksum"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"github.com/nspcc-dev/neofs-sdk-go/owner"
 	"github.com/nspcc-dev/neofs-sdk-go/version"
 )
@@ -111,7 +112,7 @@ func (r *Record) AddObjectVersionFilter(m Match, v *version.Version) {
 }
 
 // AddObjectIDFilter adds filter by object ID.
-func (r *Record) AddObjectIDFilter(m Match, id *object.ID) {
+func (r *Record) AddObjectIDFilter(m Match, id *oid.ID) {
 	r.addObjectReservedFilter(m, fKeyObjID, id)
 }
 

--- a/eacl/record_test.go
+++ b/eacl/record_test.go
@@ -10,7 +10,7 @@ import (
 	checksumtest "github.com/nspcc-dev/neofs-sdk-go/checksum/test"
 	cidtest "github.com/nspcc-dev/neofs-sdk-go/container/id/test"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
-	objecttest "github.com/nspcc-dev/neofs-sdk-go/object/test"
+	"github.com/nspcc-dev/neofs-sdk-go/object/id/test"
 	ownertest "github.com/nspcc-dev/neofs-sdk-go/owner/test"
 	versiontest "github.com/nspcc-dev/neofs-sdk-go/version/test"
 	"github.com/stretchr/testify/require"
@@ -156,7 +156,7 @@ func TestRecord_ToV2(t *testing.T) {
 func TestReservedRecords(t *testing.T) {
 	var (
 		v       = versiontest.Version()
-		oid     = objecttest.ID()
+		oid     = test.ID()
 		cid     = cidtest.ID()
 		ownerid = ownertest.ID()
 		h       = checksumtest.Checksum()

--- a/eacl/record_test.go
+++ b/eacl/record_test.go
@@ -10,7 +10,7 @@ import (
 	checksumtest "github.com/nspcc-dev/neofs-sdk-go/checksum/test"
 	cidtest "github.com/nspcc-dev/neofs-sdk-go/container/id/test"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
-	"github.com/nspcc-dev/neofs-sdk-go/object/id/test"
+	oidtest "github.com/nspcc-dev/neofs-sdk-go/object/id/test"
 	ownertest "github.com/nspcc-dev/neofs-sdk-go/owner/test"
 	versiontest "github.com/nspcc-dev/neofs-sdk-go/version/test"
 	"github.com/stretchr/testify/require"
@@ -156,7 +156,7 @@ func TestRecord_ToV2(t *testing.T) {
 func TestReservedRecords(t *testing.T) {
 	var (
 		v       = versiontest.Version()
-		oid     = test.ID()
+		oid     = oidtest.ID()
 		cid     = cidtest.ID()
 		ownerid = ownertest.ID()
 		h       = checksumtest.Checksum()

--- a/object/address/address.go
+++ b/object/address/address.go
@@ -1,4 +1,4 @@
-package object
+package address
 
 import (
 	"errors"
@@ -6,6 +6,7 @@ import (
 
 	"github.com/nspcc-dev/neofs-api-go/v2/refs"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 )
 
 // Address represents v2-compatible object address.
@@ -55,13 +56,13 @@ func (a *Address) SetContainerID(id *cid.ID) {
 }
 
 // ObjectID returns object identifier.
-func (a *Address) ObjectID() *ID {
-	return NewIDFromV2(
+func (a *Address) ObjectID() *oid.ID {
+	return oid.NewIDFromV2(
 		(*refs.Address)(a).GetObjectID())
 }
 
 // SetObjectID sets object identifier.
-func (a *Address) SetObjectID(id *ID) {
+func (a *Address) SetObjectID(id *oid.ID) {
 	(*refs.Address)(a).SetObjectID(id.ToV2())
 }
 
@@ -69,7 +70,7 @@ func (a *Address) SetObjectID(id *ID) {
 func (a *Address) Parse(s string) error {
 	var (
 		err   error
-		oid   = NewID()
+		oid   = oid.NewID()
 		id    = cid.New()
 		parts = strings.Split(s, addressSeparator)
 	)

--- a/object/address/address_test.go
+++ b/object/address/address_test.go
@@ -1,4 +1,4 @@
-package object
+package address
 
 import (
 	"strings"
@@ -6,6 +6,7 @@ import (
 
 	"github.com/nspcc-dev/neofs-api-go/v2/refs"
 	cidtest "github.com/nspcc-dev/neofs-sdk-go/container/id/test"
+	oidtest "github.com/nspcc-dev/neofs-sdk-go/object/id/test"
 	"github.com/stretchr/testify/require"
 )
 
@@ -22,7 +23,7 @@ func TestAddress_SetContainerID(t *testing.T) {
 func TestAddress_SetObjectID(t *testing.T) {
 	a := NewAddress()
 
-	oid := randID(t)
+	oid := oidtest.ID()
 
 	a.SetObjectID(oid)
 
@@ -32,8 +33,7 @@ func TestAddress_SetObjectID(t *testing.T) {
 func TestAddress_Parse(t *testing.T) {
 	cid := cidtest.ID()
 
-	oid := NewID()
-	oid.SetSHA256(randSHA256Checksum(t))
+	oid := oidtest.ID()
 
 	t.Run("should parse successful", func(t *testing.T) {
 		s := strings.Join([]string{cid.String(), oid.String()}, addressSeparator)
@@ -62,7 +62,7 @@ func TestAddress_Parse(t *testing.T) {
 
 func TestAddressEncoding(t *testing.T) {
 	a := NewAddress()
-	a.SetObjectID(randID(t))
+	a.SetObjectID(oidtest.ID())
 	a.SetContainerID(cidtest.ID())
 
 	t.Run("binary", func(t *testing.T) {

--- a/object/address/test/generate.go
+++ b/object/address/test/generate.go
@@ -1,9 +1,9 @@
 package address
 
 import (
-	"github.com/nspcc-dev/neofs-sdk-go/container/id/test"
+	cidtest "github.com/nspcc-dev/neofs-sdk-go/container/id/test"
 	"github.com/nspcc-dev/neofs-sdk-go/object/address"
-	"github.com/nspcc-dev/neofs-sdk-go/object/id/test"
+	oidtest "github.com/nspcc-dev/neofs-sdk-go/object/id/test"
 )
 
 // Address returns random object.Address.
@@ -11,7 +11,7 @@ func Address() *address.Address {
 	x := address.NewAddress()
 
 	x.SetContainerID(cidtest.ID())
-	x.SetObjectID(test.ID())
+	x.SetObjectID(oidtest.ID())
 
 	return x
 }

--- a/object/address/test/generate.go
+++ b/object/address/test/generate.go
@@ -1,0 +1,17 @@
+package address
+
+import (
+	"github.com/nspcc-dev/neofs-sdk-go/container/id/test"
+	"github.com/nspcc-dev/neofs-sdk-go/object/address"
+	"github.com/nspcc-dev/neofs-sdk-go/object/id/test"
+)
+
+// Address returns random object.Address.
+func Address() *address.Address {
+	x := address.NewAddress()
+
+	x.SetContainerID(cidtest.ID())
+	x.SetObjectID(test.ID())
+
+	return x
+}

--- a/object/fmt.go
+++ b/object/fmt.go
@@ -8,6 +8,7 @@ import (
 
 	signatureV2 "github.com/nspcc-dev/neofs-api-go/v2/signature"
 	"github.com/nspcc-dev/neofs-sdk-go/checksum"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"github.com/nspcc-dev/neofs-sdk-go/signature"
 	sigutil "github.com/nspcc-dev/neofs-sdk-go/util/signature"
 )
@@ -45,13 +46,13 @@ func VerifyPayloadChecksum(obj *Object) error {
 }
 
 // CalculateID calculates identifier for the object.
-func CalculateID(obj *Object) (*ID, error) {
+func CalculateID(obj *Object) (*oid.ID, error) {
 	data, err := obj.ToV2().GetHeader().StableMarshal(nil)
 	if err != nil {
 		return nil, err
 	}
 
-	id := NewID()
+	id := oid.NewID()
 	id.SetSHA256(sha256.Sum256(data))
 
 	return id, nil
@@ -85,7 +86,7 @@ func VerifyID(obj *Object) error {
 	return nil
 }
 
-func CalculateIDSignature(key *ecdsa.PrivateKey, id *ID) (*signature.Signature, error) {
+func CalculateIDSignature(key *ecdsa.PrivateKey, id *oid.ID) (*signature.Signature, error) {
 	sig := signature.New()
 
 	if err := sigutil.SignDataWithHandler(

--- a/object/id/id.go
+++ b/object/id/id.go
@@ -1,4 +1,4 @@
-package object
+package oid
 
 import (
 	"bytes"

--- a/object/id/id_test.go
+++ b/object/id/id_test.go
@@ -1,4 +1,4 @@
-package object
+package oid
 
 import (
 	"crypto/rand"
@@ -10,6 +10,20 @@ import (
 	"github.com/nspcc-dev/neofs-api-go/v2/refs"
 	"github.com/stretchr/testify/require"
 )
+
+func randID(t *testing.T) *ID {
+	id := NewID()
+	id.SetSHA256(randSHA256Checksum(t))
+
+	return id
+}
+
+func randSHA256Checksum(t *testing.T) (cs [sha256.Size]byte) {
+	_, err := rand.Read(cs[:])
+	require.NoError(t, err)
+
+	return
+}
 
 func TestIDV2(t *testing.T) {
 	id := NewID()

--- a/object/id/test/generate.go
+++ b/object/id/test/generate.go
@@ -1,0 +1,26 @@
+package test
+
+import (
+	"crypto/sha256"
+	"math/rand"
+
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
+)
+
+// ID returns random object.ID.
+func ID() *oid.ID {
+	checksum := [sha256.Size]byte{}
+
+	rand.Read(checksum[:])
+
+	return idWithChecksum(checksum)
+}
+
+// idWithChecksum returns object.ID initialized
+// with specified checksum.
+func idWithChecksum(cs [sha256.Size]byte) *oid.ID {
+	id := oid.NewID()
+	id.SetSHA256(cs)
+
+	return id
+}

--- a/object/raw.go
+++ b/object/raw.go
@@ -4,6 +4,7 @@ import (
 	"github.com/nspcc-dev/neofs-api-go/v2/object"
 	"github.com/nspcc-dev/neofs-sdk-go/checksum"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"github.com/nspcc-dev/neofs-sdk-go/owner"
 	"github.com/nspcc-dev/neofs-sdk-go/session"
 	"github.com/nspcc-dev/neofs-sdk-go/signature"
@@ -48,7 +49,7 @@ func (o *RawObject) Object() *Object {
 }
 
 // SetID sets object identifier.
-func (o *RawObject) SetID(v *ID) {
+func (o *RawObject) SetID(v *oid.ID) {
 	o.setID(v)
 }
 
@@ -103,12 +104,12 @@ func (o *RawObject) SetAttributes(v ...*Attribute) {
 }
 
 // SetPreviousID sets identifier of the previous sibling object.
-func (o *RawObject) SetPreviousID(v *ID) {
+func (o *RawObject) SetPreviousID(v *oid.ID) {
 	o.setPreviousID(v)
 }
 
 // SetChildren sets list of the identifiers of the child objects.
-func (o *RawObject) SetChildren(v ...*ID) {
+func (o *RawObject) SetChildren(v ...*oid.ID) {
 	o.setChildren(v...)
 }
 
@@ -118,7 +119,7 @@ func (o *RawObject) SetSplitID(id *SplitID) {
 }
 
 // SetParentID sets identifier of the parent object.
-func (o *RawObject) SetParentID(v *ID) {
+func (o *RawObject) SetParentID(v *oid.ID) {
 	o.setParentID(v)
 }
 

--- a/object/raw_test.go
+++ b/object/raw_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/nspcc-dev/neofs-api-go/v2/object"
 	"github.com/nspcc-dev/neofs-sdk-go/checksum"
 	cidtest "github.com/nspcc-dev/neofs-sdk-go/container/id/test"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	ownertest "github.com/nspcc-dev/neofs-sdk-go/owner/test"
 	sessiontest "github.com/nspcc-dev/neofs-sdk-go/session/test"
 	"github.com/nspcc-dev/neofs-sdk-go/signature"
@@ -15,8 +16,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func randID(t *testing.T) *ID {
-	id := NewID()
+func randID(t *testing.T) *oid.ID {
+	id := oid.NewID()
 	id.SetSHA256(randSHA256Checksum(t))
 
 	return id
@@ -121,7 +122,6 @@ func TestRawObject_SetCreationEpoch(t *testing.T) {
 
 func TestRawObject_SetPayloadChecksum(t *testing.T) {
 	obj := NewRaw()
-
 	cs := checksum.New()
 	cs.SetSHA256(randSHA256Checksum(t))
 
@@ -175,7 +175,7 @@ func TestRawObject_SetChildren(t *testing.T) {
 
 	obj.SetChildren(id1, id2)
 
-	require.Equal(t, []*ID{id1, id2}, obj.Children())
+	require.Equal(t, []*oid.ID{id1, id2}, obj.Children())
 }
 
 func TestRawObject_SetSplitID(t *testing.T) {

--- a/object/rw.go
+++ b/object/rw.go
@@ -5,6 +5,7 @@ import (
 	"github.com/nspcc-dev/neofs-api-go/v2/refs"
 	"github.com/nspcc-dev/neofs-sdk-go/checksum"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"github.com/nspcc-dev/neofs-sdk-go/owner"
 	"github.com/nspcc-dev/neofs-sdk-go/session"
 	"github.com/nspcc-dev/neofs-sdk-go/signature"
@@ -45,14 +46,14 @@ func (o *rwObject) setSplitFields(setter func(*object.SplitHeader)) {
 }
 
 // ID returns object identifier.
-func (o *rwObject) ID() *ID {
-	return NewIDFromV2(
+func (o *rwObject) ID() *oid.ID {
+	return oid.NewIDFromV2(
 		(*object.Object)(o).
 			GetObjectID(),
 	)
 }
 
-func (o *rwObject) setID(v *ID) {
+func (o *rwObject) setID(v *oid.ID) {
 	(*object.Object)(o).
 		SetObjectID(v.ToV2())
 }
@@ -205,8 +206,8 @@ func (o *rwObject) setAttributes(v ...*Attribute) {
 }
 
 // PreviousID returns identifier of the previous sibling object.
-func (o *rwObject) PreviousID() *ID {
-	return NewIDFromV2(
+func (o *rwObject) PreviousID() *oid.ID {
+	return oid.NewIDFromV2(
 		(*object.Object)(o).
 			GetHeader().
 			GetSplit().
@@ -214,29 +215,29 @@ func (o *rwObject) PreviousID() *ID {
 	)
 }
 
-func (o *rwObject) setPreviousID(v *ID) {
+func (o *rwObject) setPreviousID(v *oid.ID) {
 	o.setSplitFields(func(split *object.SplitHeader) {
 		split.SetPrevious(v.ToV2())
 	})
 }
 
 // Children return list of the identifiers of the child objects.
-func (o *rwObject) Children() []*ID {
+func (o *rwObject) Children() []*oid.ID {
 	ids := (*object.Object)(o).
 		GetHeader().
 		GetSplit().
 		GetChildren()
 
-	res := make([]*ID, 0, len(ids))
+	res := make([]*oid.ID, 0, len(ids))
 
 	for i := range ids {
-		res = append(res, NewIDFromV2(ids[i]))
+		res = append(res, oid.NewIDFromV2(ids[i]))
 	}
 
 	return res
 }
 
-func (o *rwObject) setChildren(v ...*ID) {
+func (o *rwObject) setChildren(v ...*oid.ID) {
 	ids := make([]*refs.ObjectID, 0, len(v))
 
 	for i := range v {
@@ -266,8 +267,8 @@ func (o *rwObject) setSplitID(id *SplitID) {
 }
 
 // ParentID returns identifier of the parent object.
-func (o *rwObject) ParentID() *ID {
-	return NewIDFromV2(
+func (o *rwObject) ParentID() *oid.ID {
+	return oid.NewIDFromV2(
 		(*object.Object)(o).
 			GetHeader().
 			GetSplit().
@@ -275,7 +276,7 @@ func (o *rwObject) ParentID() *ID {
 	)
 }
 
-func (o *rwObject) setParentID(v *ID) {
+func (o *rwObject) setParentID(v *oid.ID) {
 	o.setSplitFields(func(split *object.SplitHeader) {
 		split.SetParent(v.ToV2())
 	})

--- a/object/search.go
+++ b/object/search.go
@@ -6,6 +6,7 @@ import (
 
 	v2object "github.com/nspcc-dev/neofs-api-go/v2/object"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"github.com/nspcc-dev/neofs-sdk-go/owner"
 	"github.com/nspcc-dev/neofs-sdk-go/version"
 )
@@ -262,12 +263,12 @@ func (f *SearchFilters) AddPhyFilter() {
 }
 
 // AddParentIDFilter adds filter by parent identifier.
-func (f *SearchFilters) AddParentIDFilter(m SearchMatchType, id *ID) {
+func (f *SearchFilters) AddParentIDFilter(m SearchMatchType, id *oid.ID) {
 	f.addReservedFilter(m, fKeyParent, id)
 }
 
 // AddObjectIDFilter adds filter by object identifier.
-func (f *SearchFilters) AddObjectIDFilter(m SearchMatchType, id *ID) {
+func (f *SearchFilters) AddObjectIDFilter(m SearchMatchType, id *oid.ID) {
 	f.addReservedFilter(m, fKeyObjectID, id)
 }
 

--- a/object/search_test.go
+++ b/object/search_test.go
@@ -7,6 +7,7 @@ import (
 
 	v2object "github.com/nspcc-dev/neofs-api-go/v2/object"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"github.com/stretchr/testify/require"
 )
 
@@ -99,12 +100,12 @@ func TestSearchFilters_AddPhyFilter(t *testing.T) {
 	require.Equal(t, "", f.Value())
 }
 
-func testOID() *object.ID {
+func testOID() *oid.ID {
 	cs := [sha256.Size]byte{}
 
 	rand.Read(cs[:])
 
-	id := object.NewID()
+	id := oid.NewID()
 	id.SetSHA256(cs)
 
 	return id

--- a/object/splitinfo.go
+++ b/object/splitinfo.go
@@ -2,6 +2,7 @@ package object
 
 import (
 	"github.com/nspcc-dev/neofs-api-go/v2/object"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 )
 
 type SplitInfo object.SplitInfo
@@ -39,21 +40,21 @@ func (s *SplitInfo) SetSplitID(v *SplitID) {
 	(*object.SplitInfo)(s).SetSplitID(v.ToV2())
 }
 
-func (s *SplitInfo) LastPart() *ID {
-	return NewIDFromV2(
+func (s *SplitInfo) LastPart() *oid.ID {
+	return oid.NewIDFromV2(
 		(*object.SplitInfo)(s).GetLastPart())
 }
 
-func (s *SplitInfo) SetLastPart(v *ID) {
+func (s *SplitInfo) SetLastPart(v *oid.ID) {
 	(*object.SplitInfo)(s).SetLastPart(v.ToV2())
 }
 
-func (s *SplitInfo) Link() *ID {
-	return NewIDFromV2(
+func (s *SplitInfo) Link() *oid.ID {
+	return oid.NewIDFromV2(
 		(*object.SplitInfo)(s).GetLink())
 }
 
-func (s *SplitInfo) SetLink(v *ID) {
+func (s *SplitInfo) SetLink(v *oid.ID) {
 	(*object.SplitInfo)(s).SetLink(v.ToV2())
 }
 

--- a/object/splitinfo_test.go
+++ b/object/splitinfo_test.go
@@ -6,6 +6,7 @@ import (
 
 	objv2 "github.com/nspcc-dev/neofs-api-go/v2/object"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"github.com/stretchr/testify/require"
 )
 
@@ -43,11 +44,11 @@ func TestSplitInfo(t *testing.T) {
 	})
 }
 
-func generateID() *object.ID {
+func generateID() *oid.ID {
 	var buf [32]byte
 	_, _ = rand.Read(buf[:])
 
-	id := object.NewID()
+	id := oid.NewID()
 	id.SetSHA256(buf)
 
 	return id

--- a/object/test/generate.go
+++ b/object/test/generate.go
@@ -1,46 +1,17 @@
 package objecttest
 
 import (
-	"crypto/sha256"
-	"math/rand"
-
 	"github.com/google/uuid"
 	checksumtest "github.com/nspcc-dev/neofs-sdk-go/checksum/test"
 	cidtest "github.com/nspcc-dev/neofs-sdk-go/container/id/test"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
+	"github.com/nspcc-dev/neofs-sdk-go/object/id/test"
 	ownertest "github.com/nspcc-dev/neofs-sdk-go/owner/test"
 	sessiontest "github.com/nspcc-dev/neofs-sdk-go/session/test"
 	sigtest "github.com/nspcc-dev/neofs-sdk-go/signature/test"
 	"github.com/nspcc-dev/neofs-sdk-go/version"
 )
-
-// ID returns random object.ID.
-func ID() *object.ID {
-	checksum := [sha256.Size]byte{}
-
-	rand.Read(checksum[:])
-
-	return IDWithChecksum(checksum)
-}
-
-// IDWithChecksum returns object.ID initialized
-// with specified checksum.
-func IDWithChecksum(cs [sha256.Size]byte) *object.ID {
-	id := object.NewID()
-	id.SetSHA256(cs)
-
-	return id
-}
-
-// Address returns random object.Address.
-func Address() *object.Address {
-	x := object.NewAddress()
-
-	x.SetContainerID(cidtest.ID())
-	x.SetObjectID(ID())
-
-	return x
-}
 
 // Range returns random object.Range.
 func Range() *object.Range {
@@ -74,7 +45,7 @@ func SplitID() *object.SplitID {
 func generateRaw(withParent bool) *object.RawObject {
 	x := object.NewRaw()
 
-	x.SetID(ID())
+	x.SetID(test.ID())
 	x.SetSessionToken(sessiontest.Token())
 	x.SetPayload([]byte{1, 2, 3})
 	x.SetOwnerID(ownertest.ID())
@@ -83,9 +54,9 @@ func generateRaw(withParent bool) *object.RawObject {
 	x.SetVersion(version.Current())
 	x.SetPayloadSize(111)
 	x.SetCreationEpoch(222)
-	x.SetPreviousID(ID())
-	x.SetParentID(ID())
-	x.SetChildren(ID(), ID())
+	x.SetPreviousID(test.ID())
+	x.SetParentID(test.ID())
+	x.SetChildren(test.ID(), test.ID())
 	x.SetAttributes(Attribute(), Attribute())
 	x.SetSplitID(SplitID())
 	x.SetPayloadChecksum(checksumtest.Checksum())
@@ -115,7 +86,7 @@ func Tombstone() *object.Tombstone {
 
 	x.SetSplitID(SplitID())
 	x.SetExpirationEpoch(13)
-	x.SetMembers([]*object.ID{ID(), ID()})
+	x.SetMembers([]*oid.ID{test.ID(), test.ID()})
 
 	return x
 }
@@ -125,8 +96,8 @@ func SplitInfo() *object.SplitInfo {
 	x := object.NewSplitInfo()
 
 	x.SetSplitID(SplitID())
-	x.SetLink(ID())
-	x.SetLastPart(ID())
+	x.SetLink(test.ID())
+	x.SetLastPart(test.ID())
 
 	return x
 }
@@ -135,7 +106,7 @@ func SplitInfo() *object.SplitInfo {
 func SearchFilters() object.SearchFilters {
 	x := object.NewSearchFilters()
 
-	x.AddObjectIDFilter(object.MatchStringEqual, ID())
+	x.AddObjectIDFilter(object.MatchStringEqual, test.ID())
 	x.AddObjectContainerIDFilter(object.MatchStringNotEqual, cidtest.ID())
 
 	return x

--- a/object/test/generate.go
+++ b/object/test/generate.go
@@ -6,7 +6,7 @@ import (
 	cidtest "github.com/nspcc-dev/neofs-sdk-go/container/id/test"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
 	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
-	"github.com/nspcc-dev/neofs-sdk-go/object/id/test"
+	oidtest "github.com/nspcc-dev/neofs-sdk-go/object/id/test"
 	ownertest "github.com/nspcc-dev/neofs-sdk-go/owner/test"
 	sessiontest "github.com/nspcc-dev/neofs-sdk-go/session/test"
 	sigtest "github.com/nspcc-dev/neofs-sdk-go/signature/test"
@@ -45,7 +45,7 @@ func SplitID() *object.SplitID {
 func generateRaw(withParent bool) *object.RawObject {
 	x := object.NewRaw()
 
-	x.SetID(test.ID())
+	x.SetID(oidtest.ID())
 	x.SetSessionToken(sessiontest.Token())
 	x.SetPayload([]byte{1, 2, 3})
 	x.SetOwnerID(ownertest.ID())
@@ -54,9 +54,9 @@ func generateRaw(withParent bool) *object.RawObject {
 	x.SetVersion(version.Current())
 	x.SetPayloadSize(111)
 	x.SetCreationEpoch(222)
-	x.SetPreviousID(test.ID())
-	x.SetParentID(test.ID())
-	x.SetChildren(test.ID(), test.ID())
+	x.SetPreviousID(oidtest.ID())
+	x.SetParentID(oidtest.ID())
+	x.SetChildren(oidtest.ID(), oidtest.ID())
 	x.SetAttributes(Attribute(), Attribute())
 	x.SetSplitID(SplitID())
 	x.SetPayloadChecksum(checksumtest.Checksum())
@@ -86,7 +86,7 @@ func Tombstone() *object.Tombstone {
 
 	x.SetSplitID(SplitID())
 	x.SetExpirationEpoch(13)
-	x.SetMembers([]*oid.ID{test.ID(), test.ID()})
+	x.SetMembers([]*oid.ID{oidtest.ID(), oidtest.ID()})
 
 	return x
 }
@@ -96,8 +96,8 @@ func SplitInfo() *object.SplitInfo {
 	x := object.NewSplitInfo()
 
 	x.SetSplitID(SplitID())
-	x.SetLink(test.ID())
-	x.SetLastPart(test.ID())
+	x.SetLink(oidtest.ID())
+	x.SetLastPart(oidtest.ID())
 
 	return x
 }
@@ -106,7 +106,7 @@ func SplitInfo() *object.SplitInfo {
 func SearchFilters() object.SearchFilters {
 	x := object.NewSearchFilters()
 
-	x.AddObjectIDFilter(object.MatchStringEqual, test.ID())
+	x.AddObjectIDFilter(object.MatchStringEqual, oidtest.ID())
 	x.AddObjectContainerIDFilter(object.MatchStringNotEqual, cidtest.ID())
 
 	return x

--- a/object/tombstone.go
+++ b/object/tombstone.go
@@ -3,6 +3,7 @@ package object
 import (
 	"github.com/nspcc-dev/neofs-api-go/v2/refs"
 	"github.com/nspcc-dev/neofs-api-go/v2/tombstone"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 )
 
 // Tombstone represents v2-compatible tombstone structure.
@@ -54,7 +55,7 @@ func (t *Tombstone) SetSplitID(v *SplitID) {
 }
 
 // Members returns list of objects to be deleted.
-func (t *Tombstone) Members() []*ID {
+func (t *Tombstone) Members() []*oid.ID {
 	msV2 := (*tombstone.Tombstone)(t).
 		GetMembers()
 
@@ -62,17 +63,17 @@ func (t *Tombstone) Members() []*ID {
 		return nil
 	}
 
-	ms := make([]*ID, 0, len(msV2))
+	ms := make([]*oid.ID, 0, len(msV2))
 
 	for i := range msV2 {
-		ms = append(ms, NewIDFromV2(msV2[i]))
+		ms = append(ms, oid.NewIDFromV2(msV2[i]))
 	}
 
 	return ms
 }
 
 // SetMembers sets list of objects to be deleted.
-func (t *Tombstone) SetMembers(v []*ID) {
+func (t *Tombstone) SetMembers(v []*oid.ID) {
 	var ms []*refs.ObjectID
 
 	if v != nil {

--- a/object/tombstone_test.go
+++ b/object/tombstone_test.go
@@ -6,15 +6,16 @@ import (
 	"testing"
 
 	"github.com/nspcc-dev/neofs-api-go/v2/tombstone"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"github.com/stretchr/testify/require"
 )
 
-func generateIDList(sz int) []*ID {
-	res := make([]*ID, sz)
+func generateIDList(sz int) []*oid.ID {
+	res := make([]*oid.ID, sz)
 	cs := [sha256.Size]byte{}
 
 	for i := 0; i < sz; i++ {
-		res[i] = NewID()
+		res[i] = oid.NewID()
 		rand.Read(cs[:])
 		res[i].SetSHA256(cs)
 	}

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -22,6 +22,7 @@ import (
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	"github.com/nspcc-dev/neofs-sdk-go/eacl"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"github.com/nspcc-dev/neofs-sdk-go/owner"
 	"github.com/nspcc-dev/neofs-sdk-go/session"
 	"github.com/nspcc-dev/neofs-sdk-go/token"
@@ -157,14 +158,14 @@ type Pool interface {
 }
 
 type Object interface {
-	PutObject(ctx context.Context, params *client.PutObjectParams, opts ...CallOption) (*object.ID, error)
+	PutObject(ctx context.Context, params *client.PutObjectParams, opts ...CallOption) (*oid.ID, error)
 	DeleteObject(ctx context.Context, params *client.DeleteObjectParams, opts ...CallOption) error
 	GetObject(ctx context.Context, params *client.GetObjectParams, opts ...CallOption) (*object.Object, error)
 	GetObjectHeader(ctx context.Context, params *client.ObjectHeaderParams, opts ...CallOption) (*object.Object, error)
 	ObjectPayloadRangeData(ctx context.Context, params *client.RangeDataParams, opts ...CallOption) ([]byte, error)
 	ObjectPayloadRangeSHA256(ctx context.Context, params *client.RangeChecksumParams, opts ...CallOption) ([][32]byte, error)
 	ObjectPayloadRangeTZ(ctx context.Context, params *client.RangeChecksumParams, opts ...CallOption) ([][64]byte, error)
-	SearchObject(ctx context.Context, params *client.SearchObjectParams, opts ...CallOption) ([]*object.ID, error)
+	SearchObject(ctx context.Context, params *client.SearchObjectParams, opts ...CallOption) ([]*oid.ID, error)
 }
 
 type Container interface {
@@ -521,7 +522,7 @@ func (p *pool) checkSessionTokenErr(err error, address string) bool {
 	return false
 }
 
-func (p *pool) PutObject(ctx context.Context, params *client.PutObjectParams, opts ...CallOption) (*object.ID, error) {
+func (p *pool) PutObject(ctx context.Context, params *client.PutObjectParams, opts ...CallOption) (*oid.ID, error) {
 	cfg := cfgFromOpts(append(opts, useDefaultSession())...)
 	cp, options, err := p.conn(ctx, cfg)
 	if err != nil {
@@ -710,7 +711,7 @@ func (p *pool) ObjectPayloadRangeTZ(ctx context.Context, params *client.RangeChe
 	return hs, nil
 }
 
-func (p *pool) SearchObject(ctx context.Context, params *client.SearchObjectParams, opts ...CallOption) ([]*object.ID, error) {
+func (p *pool) SearchObject(ctx context.Context, params *client.SearchObjectParams, opts ...CallOption) ([]*oid.ID, error) {
 	cfg := cfgFromOpts(append(opts, useDefaultSession())...)
 	cp, options, err := p.conn(ctx, cfg)
 	if err != nil {

--- a/session/container.go
+++ b/session/container.go
@@ -22,12 +22,12 @@ func NewContainerContext() *ContainerContext {
 	v2 := new(session.ContainerSessionContext)
 	v2.SetWildcard(true)
 
-	return ContainerContextFromV2(v2)
+	return NewContainerContextFromV2(v2)
 }
 
-// ContainerContextFromV2 wraps session.ContainerSessionContext
+// NewContainerContextFromV2 wraps session.ContainerSessionContext
 // into ContainerContext.
-func ContainerContextFromV2(v *session.ContainerSessionContext) *ContainerContext {
+func NewContainerContextFromV2(v *session.ContainerSessionContext) *ContainerContext {
 	return (*ContainerContext)(v)
 }
 
@@ -47,7 +47,7 @@ func (x *ContainerContext) ApplyTo(id *cid.ID) {
 	v2.SetContainerID(id.ToV2())
 }
 
-// ActOnAllContainers is a helper function that conveniently
+// ApplyToAllContainers is a helper function that conveniently
 // applies ContainerContext to all containers.
 func ApplyToAllContainers(c *ContainerContext) {
 	c.ApplyTo(nil)

--- a/session/container_test.go
+++ b/session/container_test.go
@@ -57,7 +57,7 @@ func TestContainerContext_ApplyTo(t *testing.T) {
 	})
 }
 
-func TestFilter_ToV2(t *testing.T) {
+func TestContextFilter_ToV2(t *testing.T) {
 	t.Run("nil", func(t *testing.T) {
 		var x *session.ContainerContext
 

--- a/session/object.go
+++ b/session/object.go
@@ -1,0 +1,166 @@
+package session
+
+import (
+	"github.com/nspcc-dev/neofs-api-go/v2/session"
+	"github.com/nspcc-dev/neofs-sdk-go/object/address"
+)
+
+// ObjectContext represents NeoFS API v2-compatible
+// context of the object session.
+//
+// It is a wrapper over session.ObjectSessionContext
+// which allows abstracting from details of the message
+// structure.
+type ObjectContext session.ObjectSessionContext
+
+// NewObjectContext creates and returns blank ObjectContext.
+//
+// Defaults:
+//  - not bound to any operation;
+//  - nil object address.
+func NewObjectContext() *ObjectContext {
+	v2 := new(session.ObjectSessionContext)
+
+	return ObjectContextFromV2(v2)
+}
+
+// ObjectContextFromV2 wraps session.ObjectSessionContext
+// into ObjectContext.
+func ObjectContextFromV2(v *session.ObjectSessionContext) *ObjectContext {
+	return (*ObjectContext)(v)
+}
+
+// ToV2 converts ObjectContext to session.ObjectSessionContext
+// message structure.
+func (x *ObjectContext) ToV2() *session.ObjectSessionContext {
+	return (*session.ObjectSessionContext)(x)
+}
+
+// ApplyTo specifies which object the ObjectContext applies to.
+func (x *ObjectContext) ApplyTo(id *address.Address) {
+	v2 := (*session.ObjectSessionContext)(x)
+
+	v2.SetAddress(id.ToV2())
+}
+
+// Address returns identifier of the object
+// to which the ObjectContext applies.
+func (x *ObjectContext) Address() *address.Address {
+	v2 := (*session.ObjectSessionContext)(x)
+
+	return address.NewAddressFromV2(v2.GetAddress())
+}
+
+func (x *ObjectContext) forVerb(v session.ObjectSessionVerb) {
+	(*session.ObjectSessionContext)(x).
+		SetVerb(v)
+}
+
+func (x *ObjectContext) isForVerb(v session.ObjectSessionVerb) bool {
+	return (*session.ObjectSessionContext)(x).
+		GetVerb() == v
+}
+
+// ForPut binds the ObjectContext to
+// PUT operation.
+func (x *ObjectContext) ForPut() {
+	x.forVerb(session.ObjectVerbPut)
+}
+
+// IsForPut checks if ObjectContext is bound to
+// PUT operation.
+func (x *ObjectContext) IsForPut() bool {
+	return x.isForVerb(session.ObjectVerbPut)
+}
+
+// ForDelete binds the ObjectContext to
+// DELETE operation.
+func (x *ObjectContext) ForDelete() {
+	x.forVerb(session.ObjectVerbDelete)
+}
+
+// IsForDelete checks if ObjectContext is bound to
+// DELETE operation.
+func (x *ObjectContext) IsForDelete() bool {
+	return x.isForVerb(session.ObjectVerbDelete)
+}
+
+// ForGet binds the ObjectContext to
+// GET operation.
+func (x *ObjectContext) ForGet() {
+	x.forVerb(session.ObjectVerbGet)
+}
+
+// IsForGet checks if ObjectContext is bound to
+// GET operation.
+func (x *ObjectContext) IsForGet() bool {
+	return x.isForVerb(session.ObjectVerbGet)
+}
+
+// ForHead binds the ObjectContext to
+// HEAD operation.
+func (x *ObjectContext) ForHead() {
+	x.forVerb(session.ObjectVerbHead)
+}
+
+// IsForHead checks if ObjectContext is bound to
+// HEAD operation.
+func (x *ObjectContext) IsForHead() bool {
+	return x.isForVerb(session.ObjectVerbHead)
+}
+
+// ForSearch binds the ObjectContext to
+// SEARCH operation.
+func (x *ObjectContext) ForSearch() {
+	x.forVerb(session.ObjectVerbSearch)
+}
+
+// IsForSearch checks if ObjectContext is bound to
+// SEARCH operation.
+func (x *ObjectContext) IsForSearch() bool {
+	return x.isForVerb(session.ObjectVerbSearch)
+}
+
+// ForRange binds the ObjectContext to
+// RANGE operation.
+func (x *ObjectContext) ForRange() {
+	x.forVerb(session.ObjectVerbRange)
+}
+
+// IsForRange checks if ObjectContext is bound to
+// RANGE operation.
+func (x *ObjectContext) IsForRange() bool {
+	return x.isForVerb(session.ObjectVerbRange)
+}
+
+// ForRangeHash binds the ObjectContext to
+// RANGEHASH operation.
+func (x *ObjectContext) ForRangeHash() {
+	x.forVerb(session.ObjectVerbRangeHash)
+}
+
+// IsForRangeHash checks if ObjectContext is bound to
+// RANGEHASH operation.
+func (x *ObjectContext) IsForRangeHash() bool {
+	return x.isForVerb(session.ObjectVerbRangeHash)
+}
+
+// Marshal marshals ObjectContext into a protobuf binary form.
+func (x *ObjectContext) Marshal() ([]byte, error) {
+	return x.ToV2().StableMarshal(nil)
+}
+
+// Unmarshal unmarshals protobuf binary representation of ObjectContext.
+func (x *ObjectContext) Unmarshal(data []byte) error {
+	return x.ToV2().Unmarshal(data)
+}
+
+// MarshalJSON encodes ObjectContext to protobuf JSON format.
+func (x *ObjectContext) MarshalJSON() ([]byte, error) {
+	return x.ToV2().MarshalJSON()
+}
+
+// UnmarshalJSON decodes ObjectContext from protobuf JSON format.
+func (x *ObjectContext) UnmarshalJSON(data []byte) error {
+	return x.ToV2().UnmarshalJSON(data)
+}

--- a/session/object.go
+++ b/session/object.go
@@ -21,12 +21,12 @@ type ObjectContext session.ObjectSessionContext
 func NewObjectContext() *ObjectContext {
 	v2 := new(session.ObjectSessionContext)
 
-	return ObjectContextFromV2(v2)
+	return NewObjectContextFromV2(v2)
 }
 
-// ObjectContextFromV2 wraps session.ObjectSessionContext
+// NewObjectContextFromV2 wraps session.ObjectSessionContext
 // into ObjectContext.
-func ObjectContextFromV2(v *session.ObjectSessionContext) *ObjectContext {
+func NewObjectContextFromV2(v *session.ObjectSessionContext) *ObjectContext {
 	return (*ObjectContext)(v)
 }
 

--- a/session/object_test.go
+++ b/session/object_test.go
@@ -1,0 +1,123 @@
+package session_test
+
+import (
+	"testing"
+
+	v2session "github.com/nspcc-dev/neofs-api-go/v2/session"
+	objecttest "github.com/nspcc-dev/neofs-sdk-go/object/address/test"
+	"github.com/nspcc-dev/neofs-sdk-go/session"
+	sessiontest "github.com/nspcc-dev/neofs-sdk-go/session/test"
+	"github.com/stretchr/testify/require"
+)
+
+func TestObjectContextVerbs(t *testing.T) {
+	c := session.NewObjectContext()
+
+	assert := func(setter func(), getter func() bool, verb v2session.ObjectSessionVerb) {
+		setter()
+
+		require.True(t, getter())
+
+		require.Equal(t, verb, c.ToV2().GetVerb())
+	}
+
+	t.Run("PUT", func(t *testing.T) {
+		assert(c.ForPut, c.IsForPut, v2session.ObjectVerbPut)
+	})
+
+	t.Run("DELETE", func(t *testing.T) {
+		assert(c.ForDelete, c.IsForDelete, v2session.ObjectVerbDelete)
+	})
+
+	t.Run("GET", func(t *testing.T) {
+		assert(c.ForGet, c.IsForGet, v2session.ObjectVerbGet)
+	})
+
+	t.Run("SEARCH", func(t *testing.T) {
+		assert(c.ForSearch, c.IsForSearch, v2session.ObjectVerbSearch)
+	})
+
+	t.Run("RANGE", func(t *testing.T) {
+		assert(c.ForRange, c.IsForRange, v2session.ObjectVerbRange)
+	})
+
+	t.Run("RANGEHASH", func(t *testing.T) {
+		assert(c.ForRangeHash, c.IsForRangeHash, v2session.ObjectVerbRangeHash)
+	})
+
+	t.Run("HEAD", func(t *testing.T) {
+		assert(c.ForHead, c.IsForHead, v2session.ObjectVerbHead)
+	})
+}
+
+func TestObjectContext_ApplyTo(t *testing.T) {
+	c := session.NewObjectContext()
+	id := objecttest.Address()
+
+	t.Run("method", func(t *testing.T) {
+		c.ApplyTo(id)
+
+		require.Equal(t, id, c.Address())
+
+		c.ApplyTo(nil)
+
+		require.Nil(t, c.Address())
+	})
+}
+
+func TestObjectFilter_ToV2(t *testing.T) {
+	t.Run("nil", func(t *testing.T) {
+		var x *session.ObjectContext
+
+		require.Nil(t, x.ToV2())
+	})
+
+	t.Run("default values", func(t *testing.T) {
+		c := session.NewObjectContext()
+
+		// check initial values
+		require.Nil(t, c.Address())
+
+		for _, op := range []func() bool{
+			c.IsForPut,
+			c.IsForDelete,
+			c.IsForGet,
+			c.IsForHead,
+			c.IsForRange,
+			c.IsForRangeHash,
+			c.IsForSearch,
+		} {
+			require.False(t, op())
+		}
+
+		// convert to v2 message
+		cV2 := c.ToV2()
+
+		require.Equal(t, v2session.ObjectVerbUnknown, cV2.GetVerb())
+		require.Nil(t, cV2.GetAddress())
+	})
+}
+
+func TestObjectContextEncoding(t *testing.T) {
+	c := sessiontest.ObjectContext()
+
+	t.Run("binary", func(t *testing.T) {
+		data, err := c.Marshal()
+		require.NoError(t, err)
+
+		c2 := session.NewObjectContext()
+		require.NoError(t, c2.Unmarshal(data))
+
+		require.Equal(t, c, c2)
+	})
+
+	t.Run("json", func(t *testing.T) {
+		data, err := c.MarshalJSON()
+		require.NoError(t, err)
+
+		c2 := session.NewObjectContext()
+		require.NoError(t, c2.UnmarshalJSON(data))
+
+		require.Equal(t, c, c2)
+	})
+}

--- a/session/object_test.go
+++ b/session/object_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	v2session "github.com/nspcc-dev/neofs-api-go/v2/session"
-	objecttest "github.com/nspcc-dev/neofs-sdk-go/object/address/test"
+	addresstest "github.com/nspcc-dev/neofs-sdk-go/object/address/test"
 	"github.com/nspcc-dev/neofs-sdk-go/session"
 	sessiontest "github.com/nspcc-dev/neofs-sdk-go/session/test"
 	"github.com/stretchr/testify/require"
@@ -52,7 +52,7 @@ func TestObjectContextVerbs(t *testing.T) {
 
 func TestObjectContext_ApplyTo(t *testing.T) {
 	c := session.NewObjectContext()
-	id := objecttest.Address()
+	id := addresstest.Address()
 
 	t.Run("method", func(t *testing.T) {
 		c.ApplyTo(id)

--- a/session/session.go
+++ b/session/session.go
@@ -236,9 +236,9 @@ func (t *Token) Context() interface{} {
 	default:
 		return nil
 	case *session.ContainerSessionContext:
-		return ContainerContextFromV2(c)
+		return NewContainerContextFromV2(c)
 	case *session.ObjectSessionContext:
-		return ObjectContextFromV2(c)
+		return NewObjectContextFromV2(c)
 	}
 }
 

--- a/session/session.go
+++ b/session/session.go
@@ -237,6 +237,8 @@ func (t *Token) Context() interface{} {
 		return nil
 	case *session.ContainerSessionContext:
 		return ContainerContextFromV2(c)
+	case *session.ObjectSessionContext:
+		return ObjectContextFromV2(c)
 	}
 }
 

--- a/session/test/object.go
+++ b/session/test/object.go
@@ -1,0 +1,30 @@
+package sessiontest
+
+import (
+	"math/rand"
+
+	oidtest "github.com/nspcc-dev/neofs-sdk-go/object/address/test"
+	"github.com/nspcc-dev/neofs-sdk-go/session"
+)
+
+// ObjectContext returns session.ObjectContext
+// which applies to random operation on a random object.
+func ObjectContext() *session.ObjectContext {
+	c := session.NewObjectContext()
+
+	setters := []func(){
+		c.ForPut,
+		c.ForDelete,
+		c.ForHead,
+		c.ForRange,
+		c.ForRangeHash,
+		c.ForSearch,
+		c.ForGet,
+	}
+
+	setters[rand.Uint32()%uint32(len(setters))]()
+
+	c.ApplyTo(oidtest.Address())
+
+	return c
+}

--- a/session/test/object.go
+++ b/session/test/object.go
@@ -3,7 +3,7 @@ package sessiontest
 import (
 	"math/rand"
 
-	oidtest "github.com/nspcc-dev/neofs-sdk-go/object/address/test"
+	addresstest "github.com/nspcc-dev/neofs-sdk-go/object/address/test"
 	"github.com/nspcc-dev/neofs-sdk-go/session"
 )
 
@@ -24,7 +24,7 @@ func ObjectContext() *session.ObjectContext {
 
 	setters[rand.Uint32()%uint32(len(setters))]()
 
-	c.ApplyTo(oidtest.Address())
+	c.ApplyTo(addresstest.Address())
 
 	return c
 }

--- a/storagegroup/storagegroup.go
+++ b/storagegroup/storagegroup.go
@@ -4,7 +4,7 @@ import (
 	"github.com/nspcc-dev/neofs-api-go/v2/refs"
 	"github.com/nspcc-dev/neofs-api-go/v2/storagegroup"
 	"github.com/nspcc-dev/neofs-sdk-go/checksum"
-	"github.com/nspcc-dev/neofs-sdk-go/object"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 )
 
 // StorageGroup represents v2-compatible storage group.
@@ -67,17 +67,17 @@ func (sg *StorageGroup) SetExpirationEpoch(epoch uint64) {
 
 // Members returns strictly ordered list of
 // storage group member objects.
-func (sg *StorageGroup) Members() []*object.ID {
+func (sg *StorageGroup) Members() []*oid.ID {
 	mV2 := (*storagegroup.StorageGroup)(sg).GetMembers()
 
 	if mV2 == nil {
 		return nil
 	}
 
-	m := make([]*object.ID, len(mV2))
+	m := make([]*oid.ID, len(mV2))
 
 	for i := range mV2 {
-		m[i] = object.NewIDFromV2(mV2[i])
+		m[i] = oid.NewIDFromV2(mV2[i])
 	}
 
 	return m
@@ -85,7 +85,7 @@ func (sg *StorageGroup) Members() []*object.ID {
 
 // SetMembers sets strictly ordered list of
 // storage group member objects.
-func (sg *StorageGroup) SetMembers(members []*object.ID) {
+func (sg *StorageGroup) SetMembers(members []*oid.ID) {
 	mV2 := (*storagegroup.StorageGroup)(sg).GetMembers()
 
 	if members == nil {

--- a/storagegroup/storagegroup_test.go
+++ b/storagegroup/storagegroup_test.go
@@ -5,8 +5,8 @@ import (
 
 	storagegroupV2 "github.com/nspcc-dev/neofs-api-go/v2/storagegroup"
 	checksumtest "github.com/nspcc-dev/neofs-sdk-go/checksum/test"
-	"github.com/nspcc-dev/neofs-sdk-go/object"
-	objecttest "github.com/nspcc-dev/neofs-sdk-go/object/test"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
+	"github.com/nspcc-dev/neofs-sdk-go/object/id/test"
 	"github.com/nspcc-dev/neofs-sdk-go/storagegroup"
 	storagegrouptest "github.com/nspcc-dev/neofs-sdk-go/storagegroup/test"
 	"github.com/stretchr/testify/require"
@@ -27,7 +27,7 @@ func TestStorageGroup(t *testing.T) {
 	sg.SetExpirationEpoch(exp)
 	require.Equal(t, exp, sg.ExpirationEpoch())
 
-	members := []*object.ID{objecttest.ID(), objecttest.ID()}
+	members := []*oid.ID{test.ID(), test.ID()}
 	sg.SetMembers(members)
 	require.Equal(t, members, sg.Members())
 }

--- a/storagegroup/storagegroup_test.go
+++ b/storagegroup/storagegroup_test.go
@@ -6,7 +6,7 @@ import (
 	storagegroupV2 "github.com/nspcc-dev/neofs-api-go/v2/storagegroup"
 	checksumtest "github.com/nspcc-dev/neofs-sdk-go/checksum/test"
 	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
-	"github.com/nspcc-dev/neofs-sdk-go/object/id/test"
+	oidtest "github.com/nspcc-dev/neofs-sdk-go/object/id/test"
 	"github.com/nspcc-dev/neofs-sdk-go/storagegroup"
 	storagegrouptest "github.com/nspcc-dev/neofs-sdk-go/storagegroup/test"
 	"github.com/stretchr/testify/require"
@@ -27,7 +27,7 @@ func TestStorageGroup(t *testing.T) {
 	sg.SetExpirationEpoch(exp)
 	require.Equal(t, exp, sg.ExpirationEpoch())
 
-	members := []*oid.ID{test.ID(), test.ID()}
+	members := []*oid.ID{oidtest.ID(), oidtest.ID()}
 	sg.SetMembers(members)
 	require.Equal(t, members, sg.Members())
 }

--- a/storagegroup/test/generate.go
+++ b/storagegroup/test/generate.go
@@ -2,8 +2,8 @@ package storagegrouptest
 
 import (
 	checksumtest "github.com/nspcc-dev/neofs-sdk-go/checksum/test"
-	"github.com/nspcc-dev/neofs-sdk-go/object"
-	objecttest "github.com/nspcc-dev/neofs-sdk-go/object/test"
+	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
+	"github.com/nspcc-dev/neofs-sdk-go/object/id/test"
 	"github.com/nspcc-dev/neofs-sdk-go/storagegroup"
 )
 
@@ -14,7 +14,7 @@ func StorageGroup() *storagegroup.StorageGroup {
 	x.SetExpirationEpoch(66)
 	x.SetValidationDataSize(322)
 	x.SetValidationDataHash(checksumtest.Checksum())
-	x.SetMembers([]*object.ID{objecttest.ID(), objecttest.ID()})
+	x.SetMembers([]*oid.ID{test.ID(), test.ID()})
 
 	return x
 }

--- a/storagegroup/test/generate.go
+++ b/storagegroup/test/generate.go
@@ -3,7 +3,7 @@ package storagegrouptest
 import (
 	checksumtest "github.com/nspcc-dev/neofs-sdk-go/checksum/test"
 	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
-	"github.com/nspcc-dev/neofs-sdk-go/object/id/test"
+	oidtest "github.com/nspcc-dev/neofs-sdk-go/object/id/test"
 	"github.com/nspcc-dev/neofs-sdk-go/storagegroup"
 )
 
@@ -14,7 +14,7 @@ func StorageGroup() *storagegroup.StorageGroup {
 	x.SetExpirationEpoch(66)
 	x.SetValidationDataSize(322)
 	x.SetValidationDataHash(checksumtest.Checksum())
-	x.SetMembers([]*oid.ID{test.ID(), test.ID()})
+	x.SetMembers([]*oid.ID{oidtest.ID(), oidtest.ID()})
 
 	return x
 }


### PR DESCRIPTION
Alternative to #124 solution of the https://github.com/nspcc-dev/neofs-node/issues/596.

`Address` and `ID` of the object has been moved to corresponding separate packages. This is done to prevent import cycles when `object` package needs any other that requires `object.ID` or `object.Address`.