### PR TITLE
Do not resend object.Put requests in pool

### DIFF
--- a/pool/cache_test.go
+++ b/pool/cache_test.go
@@ -1,0 +1,31 @@
+package pool
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSessionCache_GetAccessTime(t *testing.T) {
+	const key = "Foo"
+
+	cache, err := NewCache()
+	require.NoError(t, err)
+
+	cache.Put(key, nil)
+
+	t1, ok := cache.GetAccessTime(key)
+	require.True(t, ok)
+
+	time.Sleep(10 * time.Millisecond)
+
+	t2, ok := cache.GetAccessTime(key)
+	require.True(t, ok)
+	require.Equal(t, t1, t2)
+
+	_ = cache.Get(key)
+	t3, ok := cache.GetAccessTime(key)
+	require.True(t, ok)
+	require.NotEqual(t, t1, t3)
+}


### PR DESCRIPTION
Closes #126 

In this PR I am trying to solve an issue when session token is invalid at `pool.PutObject()` execution. It can happen because: 
- remote storage node was restarted and all session tokens are gone,
- session token has been expired. 

Pool takes care of session token management, so it should not ignore and throw this type of errors. In other requests, pool can do a resend. `pool.PutObject()` on the other hand operates with object payload, which can be presented in a form of a stream (see NeoFS HTTP Gateway). Pool can't read payload stream twice (right now it does read it twice and produces objects with empty payload as it stated in #126). Therefore solution should remove request resend from `pool.PutObject()` and provide a way to reinitialize session token in case of an errors.

I tried several approaches.
1. gRPC channel state monitoring (https://github.com/nspcc-dev/neofs-sdk-go/issues/126#issuecomment-1027709039) works good, but it catches only remote server restarts and it won't affect the case when session token was expired. :x: 
2. Replace healthcheck request from `EndpointInfo()` to object service request, e.g. `Head()` which uses session token, so pool can catch session token related error. It didn't work, because at this point pool does not have proper object address. It can receive `invalid container ID` error before session token will be processed. :x: 
3. Do `Head()` request probe in `pool.PutObject()` (maybe with TTL=1 for faster answer). Here pool has proper container ID but it still can receive unrelated error, e.g. `access denied by ACL`. :x: 

So the last solution I come up is to reinitialize session token on every `pool.PutObject()` request. Other pool's methods remain the same. 

It is not efficient to create new session token on every request in case subsequent requests, so I came up with a small optimization: threshold on session token access. If session token was accessed before threshold value (default is 5 seconds), then do not create new session token in `pool.PutObject()`. Otherwise create new one every time.

This threshold value is configurable, but maybe it is better to hardcode it once and forever.