### PR TITLE
Replace session token expiration value with expiration duration

### DIFF
--- a/pool/pool.go
+++ b/pool/pool.go
@@ -523,7 +523,8 @@ func (p *pool) checkSessionTokenErr(err error, address string) bool {
 		return false
 	}
 
-	if strings.Contains(err.Error(), "session token does not exist") {
+	if strings.Contains(err.Error(), "session token does not exist") ||
+		strings.Contains(err.Error(), "session token has been expired") {
 		p.cache.DeleteByPrefix(address)
 		return true
 	}

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -254,6 +254,8 @@ type innerPool struct {
 	clientPacks []*clientPack
 }
 
+const DefaultSessionTokenExpirationDuration = 100 // in blocks
+
 func newPool(ctx context.Context, options *BuilderOptions) (Pool, error) {
 	cache, err := NewCache()
 	if err != nil {
@@ -299,6 +301,10 @@ func newPool(ctx context.Context, options *BuilderOptions) (Pool, error) {
 
 	if !atLeastOneHealthy {
 		return nil, fmt.Errorf("at least one node must be healthy")
+	}
+
+	if options.SessionExpirationDuration == 0 {
+		options.SessionExpirationDuration = DefaultSessionTokenExpirationDuration
 	}
 
 	ctx, cancel := context.WithCancel(ctx)

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -48,6 +48,7 @@ func TestBuildPoolCreateSessionFailed(t *testing.T) {
 		mockClient := NewMockClient(ctrl)
 		mockClient.EXPECT().CreateSession(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("error session")).AnyTimes()
 		mockClient.EXPECT().EndpointInfo(gomock.Any(), gomock.Any()).Return(&client.EndpointInfoRes{}, nil).AnyTimes()
+		mockClient.EXPECT().NetworkInfo(gomock.Any(), gomock.Any()).Return(&client.NetworkInfoRes{}, nil).AnyTimes()
 		return mockClient, nil
 	}
 
@@ -94,10 +95,12 @@ func TestBuildPoolOneNodeFailed(t *testing.T) {
 		}).AnyTimes()
 
 		mockClient.EXPECT().EndpointInfo(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+		mockClient.EXPECT().NetworkInfo(gomock.Any(), gomock.Any()).Return(&client.NetworkInfoRes{}, nil).AnyTimes()
 
 		mockClient2 := NewMockClient(ctrl2)
 		mockClient2.EXPECT().CreateSession(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 		mockClient2.EXPECT().EndpointInfo(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+		mockClient.EXPECT().NetworkInfo(gomock.Any(), gomock.Any()).Return(&client.NetworkInfoRes{}, nil).AnyTimes()
 
 		if clientCount == 0 {
 			return mockClient, nil
@@ -153,6 +156,7 @@ func TestOneNode(t *testing.T) {
 		mockClient := NewMockClient(ctrl)
 		mockClient.EXPECT().CreateSession(gomock.Any(), gomock.Any()).Return(tok, nil)
 		mockClient.EXPECT().EndpointInfo(gomock.Any(), gomock.Any()).Return(&client.EndpointInfoRes{}, nil).AnyTimes()
+		mockClient.EXPECT().NetworkInfo(gomock.Any(), gomock.Any()).Return(&client.NetworkInfoRes{}, nil).AnyTimes()
 		return mockClient, nil
 	}
 
@@ -190,6 +194,7 @@ func TestTwoNodes(t *testing.T) {
 			return tok, err
 		})
 		mockClient.EXPECT().EndpointInfo(gomock.Any(), gomock.Any()).Return(&client.EndpointInfoRes{}, nil).AnyTimes()
+		mockClient.EXPECT().NetworkInfo(gomock.Any(), gomock.Any()).Return(&client.NetworkInfoRes{}, nil).AnyTimes()
 		return mockClient, nil
 	}
 
@@ -228,6 +233,7 @@ func TestOneOfTwoFailed(t *testing.T) {
 			return tok, nil
 		}).AnyTimes()
 		mockClient.EXPECT().EndpointInfo(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+		mockClient.EXPECT().NetworkInfo(gomock.Any(), gomock.Any()).Return(&client.NetworkInfoRes{}, nil).AnyTimes()
 
 		mockClient2 := NewMockClient(ctrl2)
 		mockClient2.EXPECT().CreateSession(gomock.Any(), gomock.Any()).DoAndReturn(func(_, _ interface{}, _ ...interface{}) (*session.Token, error) {
@@ -236,6 +242,9 @@ func TestOneOfTwoFailed(t *testing.T) {
 			return tok, nil
 		}).AnyTimes()
 		mockClient2.EXPECT().EndpointInfo(gomock.Any(), gomock.Any()).DoAndReturn(func(_ interface{}, _ ...interface{}) (*client.EndpointInfoRes, error) {
+			return nil, fmt.Errorf("error")
+		}).AnyTimes()
+		mockClient2.EXPECT().NetworkInfo(gomock.Any(), gomock.Any()).DoAndReturn(func(_ interface{}, _ ...interface{}) (*client.NetworkInfoRes, error) {
 			return nil, fmt.Errorf("error")
 		}).AnyTimes()
 
@@ -277,6 +286,7 @@ func TestTwoFailed(t *testing.T) {
 		mockClient := NewMockClient(ctrl)
 		mockClient.EXPECT().CreateSession(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 		mockClient.EXPECT().EndpointInfo(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("error")).AnyTimes()
+		mockClient.EXPECT().NetworkInfo(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("error")).AnyTimes()
 		return mockClient, nil
 	}
 
@@ -379,6 +389,7 @@ func TestPriority(t *testing.T) {
 			return tok, nil
 		}).AnyTimes()
 		mockClient.EXPECT().EndpointInfo(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("error")).AnyTimes()
+		mockClient.EXPECT().NetworkInfo(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("error")).AnyTimes()
 
 		mockClient2 := NewMockClient(ctrl2)
 		mockClient2.EXPECT().CreateSession(gomock.Any(), gomock.Any()).DoAndReturn(func(_, _ interface{}, _ ...interface{}) (*session.Token, error) {
@@ -387,6 +398,7 @@ func TestPriority(t *testing.T) {
 			return tok, nil
 		}).AnyTimes()
 		mockClient2.EXPECT().EndpointInfo(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+		mockClient2.EXPECT().NetworkInfo(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 
 		if clientCount == 0 {
 			return mockClient, nil
@@ -489,6 +501,7 @@ func TestSessionTokenOwner(t *testing.T) {
 		mockClient := NewMockClient(ctrl)
 		mockClient.EXPECT().CreateSession(gomock.Any(), gomock.Any()).Return(&client.CreateSessionRes{}, nil).AnyTimes()
 		mockClient.EXPECT().EndpointInfo(gomock.Any(), gomock.Any()).Return(&client.EndpointInfoRes{}, nil).AnyTimes()
+		mockClient.EXPECT().NetworkInfo(gomock.Any(), gomock.Any()).Return(&client.NetworkInfoRes{}, nil).AnyTimes()
 		return mockClient, nil
 	}
 
@@ -527,6 +540,7 @@ func TestWaitPresence(t *testing.T) {
 	mockClient := NewMockClient(ctrl)
 	mockClient.EXPECT().CreateSession(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 	mockClient.EXPECT().EndpointInfo(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	mockClient.EXPECT().NetworkInfo(gomock.Any(), gomock.Any()).Return(&client.NetworkInfoRes{}, nil).AnyTimes()
 	mockClient.EXPECT().GetContainer(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 
 	cache, err := NewCache()


### PR DESCRIPTION
```
$ grep -I -r 'SessionExpirationEpoch' ./ 
./neofs-sftp-gw/main.go:                SessionExpirationEpoch:  math.MaxUint64,
./neofs-s3-gw/cmd/authmate/main.go:             SessionExpirationEpoch: math.MaxUint32,
./neofs-s3-gw/cmd/s3-gw/app.go:         SessionExpirationEpoch:  math.MaxUint64,
./restic/internal/backend/neofs/util.go:                SessionExpirationEpoch:  cfg.SessionExpiration,
./neofs-http-gw/app.go:         SessionExpirationEpoch:  math.MaxUint64,
./neofs-http-gw/integration_test.go:            SessionExpirationEpoch: math.MaxUint64,
```

I think it is bad to encourage developers to create infinite session tokens. To solve it I propose to specify duration in epochs and calculate absolute value directly in the pool.

---
Two more things to discuss:
1. External apps tend to use duration in real time instead of epochs (see https://github.com/nspcc-dev/neofs-http-gw/issues/108). We can do that, I suppose, but not sure if it is really needed.
2. <s>Pool manages session tokens by itself. In this case do we even need to specify session expiration time? Maybe it is okay to override the default, but default should be for 100 epochs, for example. Now there is no default value.</s> Added default value in last commit.