### PR TITLE
client: Don't accept session token params in PutContainer

### DIFF
--- a/client/container.go
+++ b/client/container.go
@@ -20,8 +20,6 @@ import (
 
 // ContainerPutPrm groups parameters of PutContainer operation.
 type ContainerPutPrm struct {
-	prmSession
-
 	cnrSet bool
 	cnr    container.Container
 }
@@ -101,8 +99,7 @@ func (c *Client) PutContainer(ctx context.Context, prm ContainerPutPrm) (*Contai
 
 	// form meta header
 	var meta v2session.RequestMetaHeader
-
-	prm.prmSession.writeToMetaHeader(&meta)
+	meta.SetSessionToken(prm.cnr.SessionToken().ToV2())
 
 	// form request
 	var req v2container.PutRequest

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -764,10 +764,6 @@ func (p *pool) PutContainer(ctx context.Context, cnr *container.Container, opts 
 		cliPrm.SetContainer(*cnr)
 	}
 
-	if cfg.stoken != nil {
-		cliPrm.SetSessionToken(*cfg.stoken)
-	}
-
 	res, err := cp.client.PutContainer(ctx, cliPrm)
 
 	if p.checkSessionTokenErr(err, cp.address) && !cfg.isRetry {


### PR DESCRIPTION
PutContainer method takes `container.Container` structure as an argument. This structure already contains session token field, so there is no need in `prmSession` because it duplicates session token definition.

In current version, `client` ignores session token from `container.Container` structure completely.