### PR TITLE
client: Customize private key in object HEAD/DELETE

### DIFF
--- a/client/common.go
+++ b/client/common.go
@@ -262,6 +262,11 @@ func (x *contextCall) processCall() bool {
 // initializes static cross-call parameters inherited from client.
 func (c *Client) initCallContext(ctx *contextCall) {
 	ctx.key = *c.opts.key
+	c.initCallContextWithoutKey(ctx)
+}
+
+// initializes static cross-call parameters inherited from client except private key.
+func (c *Client) initCallContextWithoutKey(ctx *contextCall) {
 	ctx.resolveAPIFailures = c.opts.parseNeoFSErrors
 	ctx.callbackResp = c.opts.cbRespInfo
 	ctx.netMagic = c.opts.netMagic

--- a/client/object_get.go
+++ b/client/object_get.go
@@ -383,6 +383,16 @@ func GetFullObject(ctx context.Context, c *Client, idCnr cid.ID, idObj oid.ID) (
 // PrmObjectHead groups parameters of ObjectHead operation.
 type PrmObjectHead struct {
 	prmObjectRead
+
+	keySet bool
+	key    ecdsa.PrivateKey
+}
+
+// UseKey specifies private key to sign the requests.
+// If key is not provided, then Client default key is used.
+func (x *PrmObjectHead) UseKey(key ecdsa.PrivateKey) {
+	x.keySet = true
+	x.key = key
 }
 
 // ResObjectHead groups resulting values of ObjectHead operation.
@@ -482,7 +492,13 @@ func (c *Client) ObjectHead(ctx context.Context, prm PrmObjectHead) (*ResObjectH
 
 	res.idObj = prm.obj
 
-	c.initCallContext(&cc)
+	if prm.keySet {
+		c.initCallContextWithoutKey(&cc)
+		cc.key = prm.key
+	} else {
+		c.initCallContext(&cc)
+	}
+
 	cc.req = &req
 	cc.statusRes = &res
 	cc.call = func() (responseV2, error) {

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -820,6 +820,8 @@ func (p *pool) DeleteObject(ctx context.Context, addr address.Address, opts ...C
 		prm.ByID(*obj)
 	}
 
+	prm.UseKey(*cc.key)
+
 	return p.callWithRetry(&cc, func() error {
 		_, err := cc.client.ObjectDelete(ctx, prm)
 		if err != nil {
@@ -918,6 +920,8 @@ func (p *pool) HeadObject(ctx context.Context, addr address.Address, opts ...Cal
 	if obj := addr.ObjectID(); obj != nil {
 		prm.ByID(*obj)
 	}
+
+	prm.UseKey(*cc.key)
 
 	var obj object.Object
 


### PR DESCRIPTION
We should provide the ability to customize private of object HEAD /
DELETE ops.

Implement `UseKey` method on `PrmObjectHead` / `PrmObjectDelete` types.
Sign requests with the specified key if called.

Signed-off-by: Leonard Lyubich <leonard@nspcc.ru>