### PR TITLE
signature: Add scheme

### DIFF
--- a/client/container.go
+++ b/client/container.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	v2container "github.com/nspcc-dev/neofs-api-go/v2/container"
-	"github.com/nspcc-dev/neofs-api-go/v2/refs"
 	rpcapi "github.com/nspcc-dev/neofs-api-go/v2/rpc"
 	"github.com/nspcc-dev/neofs-api-go/v2/rpc/client"
 	v2session "github.com/nspcc-dev/neofs-api-go/v2/session"
@@ -87,11 +86,8 @@ func (c *Client) ContainerPut(ctx context.Context, prm PrmContainerPut) (*ResCon
 	// sign container
 	signWrapper := v2signature.StableMarshalerWrapper{SM: reqBody.GetContainer()}
 
-	err := sigutil.SignDataWithHandler(c.opts.key, signWrapper, func(key []byte, sig []byte) {
-		containerSignature := new(refs.Signature)
-		containerSignature.SetKey(key)
-		containerSignature.SetSign(sig)
-		reqBody.SetSignature(containerSignature)
+	err := sigutil.SignDataWithHandler(c.opts.key, signWrapper, func(sig *signature.Signature) {
+		reqBody.SetSignature(sig.ToV2())
 	}, sigutil.SignWithRFC6979())
 	if err != nil {
 		return nil, err
@@ -402,11 +398,8 @@ func (c *Client) ContainerDelete(ctx context.Context, prm PrmContainerDelete) (*
 		delContainerSignWrapper{
 			body: reqBody,
 		},
-		func(key []byte, sig []byte) {
-			containerSignature := new(refs.Signature)
-			containerSignature.SetKey(key)
-			containerSignature.SetSign(sig)
-			reqBody.SetSignature(containerSignature)
+		func(sig *signature.Signature) {
+			reqBody.SetSignature(sig.ToV2())
 		},
 		sigutil.SignWithRFC6979())
 	if err != nil {
@@ -599,11 +592,8 @@ func (c *Client) ContainerSetEACL(ctx context.Context, prm PrmContainerSetEACL) 
 	// sign the eACL table
 	signWrapper := v2signature.StableMarshalerWrapper{SM: reqBody.GetEACL()}
 
-	err := sigutil.SignDataWithHandler(c.opts.key, signWrapper, func(key []byte, sig []byte) {
-		eaclSignature := new(refs.Signature)
-		eaclSignature.SetKey(key)
-		eaclSignature.SetSign(sig)
-		reqBody.SetSignature(eaclSignature)
+	err := sigutil.SignDataWithHandler(c.opts.key, signWrapper, func(sig *signature.Signature) {
+		reqBody.SetSignature(sig.ToV2())
 	}, sigutil.SignWithRFC6979())
 	if err != nil {
 		return nil, err

--- a/client/container.go
+++ b/client/container.go
@@ -86,12 +86,12 @@ func (c *Client) ContainerPut(ctx context.Context, prm PrmContainerPut) (*ResCon
 	// sign container
 	signWrapper := v2signature.StableMarshalerWrapper{SM: reqBody.GetContainer()}
 
-	err := sigutil.SignDataWithHandler(c.opts.key, signWrapper, func(sig *signature.Signature) {
-		reqBody.SetSignature(sig.ToV2())
-	}, sigutil.SignWithRFC6979())
+	sig, err := sigutil.SignData(c.opts.key, signWrapper, sigutil.SignWithRFC6979())
 	if err != nil {
 		return nil, err
 	}
+
+	reqBody.SetSignature(sig.ToV2())
 
 	// form meta header
 	var meta v2session.RequestMetaHeader
@@ -393,18 +393,15 @@ func (c *Client) ContainerDelete(ctx context.Context, prm PrmContainerDelete) (*
 	reqBody := new(v2container.DeleteRequestBody)
 	reqBody.SetContainerID(prm.id.ToV2())
 
+	signWrapper := delContainerSignWrapper{body: reqBody}
+
 	// sign container
-	err := sigutil.SignDataWithHandler(c.opts.key,
-		delContainerSignWrapper{
-			body: reqBody,
-		},
-		func(sig *signature.Signature) {
-			reqBody.SetSignature(sig.ToV2())
-		},
-		sigutil.SignWithRFC6979())
+	sig, err := sigutil.SignData(c.opts.key, signWrapper, sigutil.SignWithRFC6979())
 	if err != nil {
 		return nil, err
 	}
+
+	reqBody.SetSignature(sig.ToV2())
 
 	// form meta header
 	var meta v2session.RequestMetaHeader
@@ -592,12 +589,12 @@ func (c *Client) ContainerSetEACL(ctx context.Context, prm PrmContainerSetEACL) 
 	// sign the eACL table
 	signWrapper := v2signature.StableMarshalerWrapper{SM: reqBody.GetEACL()}
 
-	err := sigutil.SignDataWithHandler(c.opts.key, signWrapper, func(sig *signature.Signature) {
-		reqBody.SetSignature(sig.ToV2())
-	}, sigutil.SignWithRFC6979())
+	sig, err := sigutil.SignData(c.opts.key, signWrapper, sigutil.SignWithRFC6979())
 	if err != nil {
 		return nil, err
 	}
+
+	reqBody.SetSignature(sig.ToV2())
 
 	// form meta header
 	var meta v2session.RequestMetaHeader

--- a/object/fmt.go
+++ b/object/fmt.go
@@ -87,21 +87,11 @@ func VerifyID(obj *Object) error {
 }
 
 func CalculateIDSignature(key *ecdsa.PrivateKey, id *oid.ID) (*signature.Signature, error) {
-	sig := signature.New()
-
-	if err := sigutil.SignDataWithHandler(
+	return sigutil.SignData(
 		key,
 		signatureV2.StableMarshalerWrapper{
 			SM: id.ToV2(),
-		},
-		func(s *signature.Signature) {
-			*sig = *s
-		},
-	); err != nil {
-		return nil, err
-	}
-
-	return sig, nil
+		})
 }
 
 func CalculateAndSetSignature(key *ecdsa.PrivateKey, obj *RawObject) error {
@@ -116,11 +106,11 @@ func CalculateAndSetSignature(key *ecdsa.PrivateKey, obj *RawObject) error {
 }
 
 func VerifyIDSignature(obj *Object) error {
-	return sigutil.VerifyDataWithSource(
+	return sigutil.VerifyData(
 		signatureV2.StableMarshalerWrapper{
 			SM: obj.ID().ToV2(),
 		},
-		obj.Signature,
+		obj.Signature(),
 	)
 }
 

--- a/object/fmt.go
+++ b/object/fmt.go
@@ -94,9 +94,8 @@ func CalculateIDSignature(key *ecdsa.PrivateKey, id *oid.ID) (*signature.Signatu
 		signatureV2.StableMarshalerWrapper{
 			SM: id.ToV2(),
 		},
-		func(key, sign []byte) {
-			sig.SetKey(key)
-			sig.SetSign(sign)
+		func(s *signature.Signature) {
+			*sig = *s
 		},
 	); err != nil {
 		return nil, err
@@ -121,11 +120,7 @@ func VerifyIDSignature(obj *Object) error {
 		signatureV2.StableMarshalerWrapper{
 			SM: obj.ID().ToV2(),
 		},
-		func() ([]byte, []byte) {
-			sig := obj.Signature()
-
-			return sig.Key(), sig.Sign()
-		},
+		obj.Signature,
 	)
 }
 

--- a/reputation/trust.go
+++ b/reputation/trust.go
@@ -260,13 +260,14 @@ func (x *GlobalTrust) Trust() *Trust {
 func (x *GlobalTrust) Sign(key *ecdsa.PrivateKey) error {
 	v2 := (*reputation.GlobalTrust)(x)
 
-	return sigutil.SignDataWithHandler(
-		key,
-		signatureV2.StableMarshalerWrapper{SM: v2.GetBody()},
-		func(sig *signature.Signature) {
-			v2.SetSignature(sig.ToV2())
-		},
-	)
+	sig, err := sigutil.SignData(key,
+		signatureV2.StableMarshalerWrapper{SM: v2.GetBody()})
+	if err != nil {
+		return err
+	}
+
+	v2.SetSignature(sig.ToV2())
+	return nil
 }
 
 // VerifySignature verifies global trust signature.
@@ -278,11 +279,9 @@ func (x *GlobalTrust) VerifySignature() error {
 		sigV2 = new(refs.Signature)
 	}
 
-	return sigutil.VerifyDataWithSource(
+	return sigutil.VerifyData(
 		signatureV2.StableMarshalerWrapper{SM: v2.GetBody()},
-		func() *signature.Signature {
-			return signature.NewFromV2(sigV2)
-		},
+		signature.NewFromV2(sigV2),
 	)
 }
 

--- a/session/session.go
+++ b/session/session.go
@@ -168,9 +168,13 @@ func (t *Token) Sign(key *ecdsa.PrivateKey) error {
 		SM: tV2.GetBody(),
 	}
 
-	return sigutil.SignDataWithHandler(key, signedData, func(sig *signature.Signature) {
-		tV2.SetSignature(sig.ToV2())
-	})
+	sig, err := sigutil.SignData(key, signedData)
+	if err != nil {
+		return err
+	}
+
+	tV2.SetSignature(sig.ToV2())
+	return nil
 }
 
 // VerifySignature checks if token signature is
@@ -182,7 +186,7 @@ func (t *Token) VerifySignature() bool {
 		SM: tV2.GetBody(),
 	}
 
-	return sigutil.VerifyDataWithSource(signedData, t.Signature) == nil
+	return sigutil.VerifyData(signedData, t.Signature()) == nil
 }
 
 // Signature returns Token signature.

--- a/session/session.go
+++ b/session/session.go
@@ -3,7 +3,6 @@ package session
 import (
 	"crypto/ecdsa"
 
-	"github.com/nspcc-dev/neofs-api-go/v2/refs"
 	"github.com/nspcc-dev/neofs-api-go/v2/session"
 	v2signature "github.com/nspcc-dev/neofs-api-go/v2/signature"
 	"github.com/nspcc-dev/neofs-sdk-go/owner"
@@ -169,16 +168,8 @@ func (t *Token) Sign(key *ecdsa.PrivateKey) error {
 		SM: tV2.GetBody(),
 	}
 
-	return sigutil.SignDataWithHandler(key, signedData, func(key, sig []byte) {
-		tSig := tV2.GetSignature()
-		if tSig == nil {
-			tSig = new(refs.Signature)
-		}
-
-		tSig.SetKey(key)
-		tSig.SetSign(sig)
-
-		tV2.SetSignature(tSig)
+	return sigutil.SignDataWithHandler(key, signedData, func(sig *signature.Signature) {
+		tV2.SetSignature(sig.ToV2())
 	})
 }
 
@@ -191,10 +182,7 @@ func (t *Token) VerifySignature() bool {
 		SM: tV2.GetBody(),
 	}
 
-	return sigutil.VerifyDataWithSource(signedData, func() (key, sig []byte) {
-		tSig := tV2.GetSignature()
-		return tSig.GetKey(), tSig.GetSign()
-	}) == nil
+	return sigutil.VerifyDataWithSource(signedData, t.Signature) == nil
 }
 
 // Signature returns Token signature.

--- a/signature/signature.go
+++ b/signature/signature.go
@@ -7,6 +7,16 @@ import (
 // Signature represents v2-compatible signature.
 type Signature refs.Signature
 
+// Scheme represents signature scheme.
+type Scheme uint32
+
+// Supported signature schemes.
+const (
+	Unspecified Scheme = iota
+	ECDSAWithSHA512
+	RFC6979WithSHA256
+)
+
 // NewFromV2 wraps v2 Signature message to Signature.
 //
 // Nil refs.Signature converts to nil.
@@ -41,6 +51,16 @@ func (s *Signature) Sign() []byte {
 // SetSign sets signature value.
 func (s *Signature) SetSign(v []byte) {
 	(*refs.Signature)(s).SetSign(v)
+}
+
+// Scheme returns signature scheme.
+func (s *Signature) Scheme() Scheme {
+	return Scheme((*refs.Signature)(s).GetScheme())
+}
+
+// SetScheme sets signature scheme.
+func (s *Signature) SetScheme(v Scheme) {
+	(*refs.Signature)(s).SetScheme(refs.SignatureScheme(v))
 }
 
 // ToV2 converts Signature to v2 Signature message.

--- a/util/signature/options.go
+++ b/util/signature/options.go
@@ -9,38 +9,65 @@ import (
 	"math/big"
 
 	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
+	"github.com/nspcc-dev/neofs-sdk-go/signature"
 )
 
 var curve = elliptic.P256()
 
 type cfg struct {
-	signFunc   func(key *ecdsa.PrivateKey, msg []byte) ([]byte, error)
-	verifyFunc func(key *ecdsa.PublicKey, msg []byte, sig []byte) error
+	defaultScheme  signature.Scheme
+	restrictScheme signature.Scheme
 }
 
-func defaultCfg() *cfg {
-	return &cfg{
-		signFunc:   sign,
-		verifyFunc: verify,
+func getConfig(opts ...SignOption) *cfg {
+	cfg := &cfg{
+		defaultScheme:  signature.ECDSAWithSHA512,
+		restrictScheme: signature.Unspecified,
+	}
+
+	for i := range opts {
+		opts[i](cfg)
+	}
+
+	return cfg
+}
+
+func sign(scheme signature.Scheme, key *ecdsa.PrivateKey, msg []byte) ([]byte, error) {
+	switch scheme {
+	case signature.ECDSAWithSHA512:
+		h := sha512.Sum512(msg)
+		x, y, err := ecdsa.Sign(rand.Reader, key, h[:])
+		if err != nil {
+			return nil, err
+		}
+		return elliptic.Marshal(elliptic.P256(), x, y), nil
+	case signature.RFC6979WithSHA256:
+		p := &keys.PrivateKey{PrivateKey: *key}
+		return p.Sign(msg), nil
+	default:
+		panic("unsupported scheme")
 	}
 }
 
-func sign(key *ecdsa.PrivateKey, msg []byte) ([]byte, error) {
-	h := sha512.Sum512(msg)
-	x, y, err := ecdsa.Sign(rand.Reader, key, h[:])
-	if err != nil {
-		return nil, err
+func verify(scheme signature.Scheme, key *ecdsa.PublicKey, msg []byte, sig []byte) error {
+	switch scheme {
+	case signature.ECDSAWithSHA512:
+		h := sha512.Sum512(msg)
+		r, s := unmarshalXY(sig)
+		if r != nil && s != nil && ecdsa.Verify(key, h[:], r, s) {
+			return nil
+		}
+		return ErrInvalidSignature
+	case signature.RFC6979WithSHA256:
+		p := (*keys.PublicKey)(key)
+		h := sha256.Sum256(msg)
+		if p.Verify(sig, h[:]) {
+			return nil
+		}
+		return ErrInvalidSignature
+	default:
+		return ErrInvalidSignature
 	}
-	return elliptic.Marshal(elliptic.P256(), x, y), nil
-}
-
-func verify(key *ecdsa.PublicKey, msg []byte, sig []byte) error {
-	h := sha512.Sum512(msg)
-	r, s := unmarshalXY(sig)
-	if r != nil && s != nil && ecdsa.Verify(key, h[:], r, s) {
-		return nil
-	}
-	return ErrInvalidSignature
 }
 
 // unmarshalXY converts a point, serialized by Marshal, into an x, y pair.
@@ -71,21 +98,7 @@ func unmarshalXY(data []byte) (x *big.Int, y *big.Int) {
 
 func SignWithRFC6979() SignOption {
 	return func(c *cfg) {
-		c.signFunc = signRFC6979
-		c.verifyFunc = verifyRFC6979
+		c.defaultScheme = signature.RFC6979WithSHA256
+		c.restrictScheme = signature.RFC6979WithSHA256
 	}
-}
-
-func signRFC6979(key *ecdsa.PrivateKey, msg []byte) ([]byte, error) {
-	p := &keys.PrivateKey{PrivateKey: *key}
-	return p.Sign(msg), nil
-}
-
-func verifyRFC6979(key *ecdsa.PublicKey, msg []byte, sig []byte) error {
-	p := (*keys.PublicKey)(key)
-	h := sha256.Sum256(msg)
-	if p.Verify(sig, h[:]) {
-		return nil
-	}
-	return ErrInvalidSignature
 }


### PR DESCRIPTION
Allow `SignOption` to set 2 parameters:
1. Default signature scheme, which is used in case scheme is
   unspecified.
2. Restrict scheme option which also checks that scheme is either
   unspecified or equal to the restricted scheme. This is only used
   for verification and is necessary because some of the signatures
   are used in smart-contracts.

Also provide signature struct to sign/verify functions in helpers.

Signed-off-by: Evgenii Stratonikov <evgeniy@nspcc.ru>