### PR TITLE
signature: Change scheme selection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/mr-tron/base58 v1.2.0
 	github.com/nspcc-dev/hrw v1.0.9
 	github.com/nspcc-dev/neo-go v0.98.0
-	github.com/nspcc-dev/neofs-api-go/v2 v2.12.0
+	github.com/nspcc-dev/neofs-api-go/v2 v2.11.2-0.20220302134950-d065453bd0a7
 	github.com/stretchr/testify v1.7.0
 	go.uber.org/zap v1.18.1
 	google.golang.org/grpc v1.41.0

--- a/go.sum
+++ b/go.sum
@@ -177,8 +177,8 @@ github.com/nspcc-dev/neo-go v0.73.1-pre.0.20200303142215-f5a1b928ce09/go.mod h1:
 github.com/nspcc-dev/neo-go v0.98.0 h1:yyW4sgY88/pLf0949qmgfkQXzRKC3CI/WyhqXNnwMd8=
 github.com/nspcc-dev/neo-go v0.98.0/go.mod h1:E3cc1x6RXSXrJb2nDWXTXjnXk3rIqVN8YdFyWv+FrqM=
 github.com/nspcc-dev/neofs-api-go/v2 v2.11.0-pre.0.20211201134523-3604d96f3fe1/go.mod h1:oS8dycEh8PPf2Jjp6+8dlwWyEv2Dy77h/XhhcdxYEFs=
-github.com/nspcc-dev/neofs-api-go/v2 v2.12.0 h1:xWqXzorDk9WFMTtWP7cwwlyJDL1X6Z4HT1e5zqkq7xY=
-github.com/nspcc-dev/neofs-api-go/v2 v2.12.0/go.mod h1:oS8dycEh8PPf2Jjp6+8dlwWyEv2Dy77h/XhhcdxYEFs=
+github.com/nspcc-dev/neofs-api-go/v2 v2.11.2-0.20220302134950-d065453bd0a7 h1:hLMvj4K9djzBg+TaeDGQWGuohzXvcThi0r0LSLhhi3M=
+github.com/nspcc-dev/neofs-api-go/v2 v2.11.2-0.20220302134950-d065453bd0a7/go.mod h1:oS8dycEh8PPf2Jjp6+8dlwWyEv2Dy77h/XhhcdxYEFs=
 github.com/nspcc-dev/neofs-crypto v0.2.0/go.mod h1:F/96fUzPM3wR+UGsPi3faVNmFlA9KAEAUQR7dMxZmNA=
 github.com/nspcc-dev/neofs-crypto v0.2.3/go.mod h1:8w16GEJbH6791ktVqHN9YRNH3s9BEEKYxGhlFnp0cDw=
 github.com/nspcc-dev/neofs-crypto v0.3.0 h1:zlr3pgoxuzrmGCxc5W8dGVfA9Rro8diFvVnBg0L4ifM=

--- a/signature/signature.go
+++ b/signature/signature.go
@@ -12,10 +12,13 @@ type Scheme uint32
 
 // Supported signature schemes.
 const (
-	Unspecified Scheme = iota
-	ECDSAWithSHA512
+	ECDSAWithSHA512 Scheme = iota
 	RFC6979WithSHA256
 )
+
+func (x Scheme) String() string {
+	return refs.SignatureScheme(x).String()
+}
 
 // NewFromV2 wraps v2 Signature message to Signature.
 //

--- a/util/signature/data.go
+++ b/util/signature/data.go
@@ -57,7 +57,7 @@ func SignData(key *ecdsa.PrivateKey, src DataSource, opts ...SignOption) (*signa
 
 	cfg := getConfig(opts...)
 
-	sigData, err := sign(cfg.defaultScheme, key, data)
+	sigData, err := sign(cfg.scheme, key, data)
 	if err != nil {
 		return nil, err
 	}
@@ -65,7 +65,7 @@ func SignData(key *ecdsa.PrivateKey, src DataSource, opts ...SignOption) (*signa
 	sig := signature.New()
 	sig.SetKey((*keys.PublicKey)(&key.PublicKey).Bytes())
 	sig.SetSign(sigData)
-	sig.SetScheme(cfg.defaultScheme)
+	sig.SetScheme(cfg.scheme)
 	return sig, nil
 }
 


### PR DESCRIPTION
`SignData`: use `ECDSAWithSHA512` by default. `SignWithRFC6979` option
switches the scheme to `RFC6979WithSHA256`.

`VerifyData`: if scheme is not fixed (like by `SignWithRFC6979` option)
then scheme from the message is processed.

Signed-off-by: Leonard Lyubich <leonard@nspcc.ru>