### PR TITLE
[#180] eacl: add EqualTo

### DIFF
--- a/eacl/filter.go
+++ b/eacl/filter.go
@@ -174,3 +174,11 @@ func (f *Filter) UnmarshalJSON(data []byte) error {
 
 	return nil
 }
+
+// equalFilters compares Filter with each other.
+func equalFilters(f1, f2 Filter) bool {
+	return f1.From() == f2.From() &&
+		f1.Matcher() == f2.Matcher() &&
+		f1.Key() == f2.Key() &&
+		f1.Value() == f2.Value()
+}

--- a/eacl/record.go
+++ b/eacl/record.go
@@ -267,3 +267,33 @@ func (r *Record) UnmarshalJSON(data []byte) error {
 
 	return nil
 }
+
+// equalRecords compares Record with each other.
+func equalRecords(r1, r2 Record) bool {
+	if r1.Operation() != r2.Operation() ||
+		r1.Action() != r2.Action() {
+		return false
+	}
+
+	fs1, fs2 := r1.Filters(), r2.Filters()
+	ts1, ts2 := r1.Targets(), r2.Targets()
+
+	if len(fs1) != len(fs2) ||
+		len(ts1) != len(ts2) {
+		return false
+	}
+
+	for i := 0; i < len(fs1); i++ {
+		if !equalFilters(fs1[i], fs2[i]) {
+			return false
+		}
+	}
+
+	for i := 0; i < len(ts1); i++ {
+		if !equalTargets(ts1[i], ts2[i]) {
+			return false
+		}
+	}
+
+	return true
+}

--- a/eacl/target.go
+++ b/eacl/target.go
@@ -1,6 +1,7 @@
 package eacl
 
 import (
+	"bytes"
 	"crypto/ecdsa"
 
 	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
@@ -154,4 +155,25 @@ func (t *Target) UnmarshalJSON(data []byte) error {
 	*t = *NewTargetFromV2(tV2)
 
 	return nil
+}
+
+// equalTargets compares Target with each other.
+func equalTargets(t1, t2 Target) bool {
+	if t1.Role() != t2.Role() {
+		return false
+	}
+
+	keys1, keys2 := t1.BinaryKeys(), t2.BinaryKeys()
+
+	if len(keys1) != len(keys2) {
+		return false
+	}
+
+	for i := 0; i < len(keys1); i++ {
+		if !bytes.Equal(keys1[i], keys2[i]) {
+			return false
+		}
+	}
+
+	return true
 }

--- a/eacl/test/benchmark_test.go
+++ b/eacl/test/benchmark_test.go
@@ -27,7 +27,7 @@ func baseBenchmarkTableBinaryComparison(b *testing.B, factor int) {
 	}
 }
 
-func baseBenchmarkTableEqualToComparison(b *testing.B, factor int) {
+func baseBenchmarkTableEqualsComparison(b *testing.B, factor int) {
 	t := TableN(factor)
 	data, err := t.Marshal()
 	require.NoError(b, err)
@@ -39,7 +39,7 @@ func baseBenchmarkTableEqualToComparison(b *testing.B, factor int) {
 	b.ResetTimer()
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
-		if !t.EqualTo(t2) {
+		if !eacl.EqualTables(*t, *t2) {
 			b.Fail()
 		}
 	}
@@ -49,24 +49,24 @@ func BenchmarkTableBinaryComparison(b *testing.B) {
 	baseBenchmarkTableBinaryComparison(b, 1)
 }
 
-func BenchmarkTableEqualToComparison(b *testing.B) {
-	baseBenchmarkTableEqualToComparison(b, 1)
+func BenchmarkTableEqualsComparison(b *testing.B) {
+	baseBenchmarkTableEqualsComparison(b, 1)
 }
 
 func BenchmarkTableBinaryComparison10(b *testing.B) {
 	baseBenchmarkTableBinaryComparison(b, 10)
 }
 
-func BenchmarkTableEqualToComparison10(b *testing.B) {
-	baseBenchmarkTableEqualToComparison(b, 10)
+func BenchmarkTableEqualsComparison10(b *testing.B) {
+	baseBenchmarkTableEqualsComparison(b, 10)
 }
 
 func BenchmarkTableBinaryComparison100(b *testing.B) {
 	baseBenchmarkTableBinaryComparison(b, 100)
 }
 
-func BenchmarkTableEqualToComparison100(b *testing.B) {
-	baseBenchmarkTableEqualToComparison(b, 100)
+func BenchmarkTableEqualsComparison100(b *testing.B) {
+	baseBenchmarkTableEqualsComparison(b, 100)
 }
 
 // Target returns random eacl.Target.

--- a/eacl/test/benchmark_test.go
+++ b/eacl/test/benchmark_test.go
@@ -1,0 +1,116 @@
+package eacltest
+
+import (
+	"bytes"
+	"math/rand"
+	"testing"
+
+	cidtest "github.com/nspcc-dev/neofs-sdk-go/container/id/test"
+	"github.com/nspcc-dev/neofs-sdk-go/eacl"
+	versiontest "github.com/nspcc-dev/neofs-sdk-go/version/test"
+	"github.com/stretchr/testify/require"
+)
+
+func baseBenchmarkTableBinaryComparison(b *testing.B, factor int) {
+	t := TableN(factor)
+	exp, err := t.Marshal()
+	require.NoError(b, err)
+
+	b.StopTimer()
+	b.ResetTimer()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		got, _ := t.Marshal()
+		if !bytes.Equal(exp, got) {
+			b.Fail()
+		}
+	}
+}
+
+func baseBenchmarkTableEqualToComparison(b *testing.B, factor int) {
+	t := TableN(factor)
+	data, err := t.Marshal()
+	require.NoError(b, err)
+	t2 := eacl.NewTable()
+	err = t2.Unmarshal(data)
+	require.NoError(b, err)
+
+	b.StopTimer()
+	b.ResetTimer()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if !t.EqualTo(t2) {
+			b.Fail()
+		}
+	}
+}
+
+func BenchmarkTableBinaryComparison(b *testing.B) {
+	baseBenchmarkTableBinaryComparison(b, 1)
+}
+
+func BenchmarkTableEqualToComparison(b *testing.B) {
+	baseBenchmarkTableEqualToComparison(b, 1)
+}
+
+func BenchmarkTableBinaryComparison10(b *testing.B) {
+	baseBenchmarkTableBinaryComparison(b, 10)
+}
+
+func BenchmarkTableEqualToComparison10(b *testing.B) {
+	baseBenchmarkTableEqualToComparison(b, 10)
+}
+
+func BenchmarkTableBinaryComparison100(b *testing.B) {
+	baseBenchmarkTableBinaryComparison(b, 100)
+}
+
+func BenchmarkTableEqualToComparison100(b *testing.B) {
+	baseBenchmarkTableEqualToComparison(b, 100)
+}
+
+// Target returns random eacl.Target.
+func TargetN(n int) *eacl.Target {
+	x := eacl.NewTarget()
+
+	x.SetRole(eacl.RoleSystem)
+	keys := make([][]byte, n)
+
+	for i := 0; i < n; i++ {
+		keys[i] = make([]byte, 32)
+		rand.Read(keys[i])
+	}
+
+	x.SetBinaryKeys(keys)
+
+	return x
+}
+
+// Record returns random eacl.Record.
+func RecordN(n int) *eacl.Record {
+	x := eacl.NewRecord()
+
+	x.SetAction(eacl.ActionAllow)
+	x.SetOperation(eacl.OperationRangeHash)
+	x.SetTargets(*TargetN(n))
+
+	for i := 0; i < n; i++ {
+		x.AddFilter(eacl.HeaderFromObject, eacl.MatchStringEqual, "", cidtest.ID().String())
+	}
+
+	return x
+}
+
+func TableN(n int) *eacl.Table {
+	x := eacl.NewTable()
+
+	x.SetCID(cidtest.ID())
+
+	for i := 0; i < n; i++ {
+		x.AddRecord(RecordN(n))
+	}
+
+	x.SetVersion(*versiontest.Version())
+
+	return x
+}

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -1577,7 +1577,7 @@ func waitForEACLPresence(ctx context.Context, pool *Pool, cnrID *cid.ID, table *
 	return waitFor(ctx, waitParams, func(ctx context.Context) bool {
 		eaclTable, err := pool.GetEACL(ctx, prm)
 		if err == nil {
-			return table.EqualTo(eaclTable)
+			return eacl.EqualTables(*table, *eaclTable)
 		}
 		return false
 	})

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -1520,6 +1520,19 @@ func WaitForEACLPresence(ctx context.Context, pool *Pool, cnrID *cid.ID, table *
 	})
 }
 
+// WaitForContainerRemoved waits until the container is removed from the NeoFS network.
+func WaitForContainerRemoved(ctx context.Context, pool *Pool, cnrID *cid.ID, waitParams *WaitParams) error {
+	var prm PrmContainerGet
+	if cnrID != nil {
+		prm.SetContainerID(*cnrID)
+	}
+
+	return waitFor(ctx, waitParams, func(ctx context.Context) bool {
+		_, err := pool.GetContainer(ctx, prm)
+		return sdkClient.IsErrContainerNotFound(err)
+	})
+}
+
 // waitFor await that given condition will be met in waitParams time.
 func waitFor(ctx context.Context, params *WaitParams, condition func(context.Context) bool) error {
 	wctx, cancel := context.WithTimeout(ctx, params.timeout)

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -615,14 +615,14 @@ func TestWaitPresence(t *testing.T) {
 			cancel()
 		}()
 
-		err := WaitForContainerPresence(ctx, p, nil, DefaultPollingParams())
+		err := WaitForContainerPresence(ctx, p, nil, DefaultWaitParams())
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "context canceled")
 	})
 
 	t.Run("context deadline exceeded", func(t *testing.T) {
 		ctx := context.Background()
-		err := WaitForContainerPresence(ctx, p, nil, &ContainerPollingParams{
+		err := WaitForContainerPresence(ctx, p, nil, &WaitParams{
 			timeout:      500 * time.Millisecond,
 			pollInterval: 5 * time.Second,
 		})
@@ -632,7 +632,7 @@ func TestWaitPresence(t *testing.T) {
 
 	t.Run("ok", func(t *testing.T) {
 		ctx := context.Background()
-		err := WaitForContainerPresence(ctx, p, nil, &ContainerPollingParams{
+		err := WaitForContainerPresence(ctx, p, nil, &WaitParams{
 			timeout:      10 * time.Second,
 			pollInterval: 500 * time.Millisecond,
 		})

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -615,14 +615,17 @@ func TestWaitPresence(t *testing.T) {
 			cancel()
 		}()
 
-		err := WaitForContainerPresence(ctx, p, nil, DefaultWaitParams())
+		err = waitForContainerPresence(ctx, p, nil, &WaitParams{
+			timeout:      120 * time.Second,
+			pollInterval: 5 * time.Second,
+		})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "context canceled")
 	})
 
 	t.Run("context deadline exceeded", func(t *testing.T) {
 		ctx := context.Background()
-		err := WaitForContainerPresence(ctx, p, nil, &WaitParams{
+		err := waitForContainerPresence(ctx, p, nil, &WaitParams{
 			timeout:      500 * time.Millisecond,
 			pollInterval: 5 * time.Second,
 		})
@@ -632,7 +635,7 @@ func TestWaitPresence(t *testing.T) {
 
 	t.Run("ok", func(t *testing.T) {
 		ctx := context.Background()
-		err := WaitForContainerPresence(ctx, p, nil, &WaitParams{
+		err := waitForContainerPresence(ctx, p, nil, &WaitParams{
 			timeout:      10 * time.Second,
 			pollInterval: 500 * time.Millisecond,
 		})

--- a/version/version.go
+++ b/version/version.go
@@ -87,3 +87,9 @@ func (v *Version) MarshalJSON() ([]byte, error) {
 func (v *Version) UnmarshalJSON(data []byte) error {
 	return (*refs.Version)(v).UnmarshalJSON(data)
 }
+
+// Equal returns true if versions are identical.
+func (v Version) Equal(v2 Version) bool {
+	return v.Major() == v2.Major() &&
+		v.Minor() == v2.Minor()
+}


### PR DESCRIPTION
Using `EqualTo` is faster than binary comparison (scenario: waiting eacl presence). When we have unmarshaled eacl table (that's true for `waitForEACLPresence`) it's easier to compare by records rather than marshal and compare in binary form.

Suffix numbers in benchmark names are lengths records, filters, targets in table.
```
BenchmarkTableBinaryComparison
BenchmarkTableBinaryComparison-16        	  289216	      4000 ns/op
BenchmarkTableEqualToComparison
BenchmarkTableEqualToComparison-16       	11110905	       102.5 ns/op
BenchmarkTableBinaryComparison10
BenchmarkTableBinaryComparison10-16      	    6127	    182411 ns/op
BenchmarkTableEqualToComparison10
BenchmarkTableEqualToComparison10-16     	  238905	      5073 ns/op
BenchmarkTableBinaryComparison100
BenchmarkTableBinaryComparison100-16     	      93	  14451912 ns/op
BenchmarkTableEqualToComparison100
BenchmarkTableEqualToComparison100-16    	    2202	    622850 ns/op
```

related to https://github.com/nspcc-dev/neofs-s3-gw/issues/365