### PR TITLE
Fix/copy token

### DIFF
--- a/pool/cache.go
+++ b/pool/cache.go
@@ -26,6 +26,9 @@ func newCache() (*sessionCache, error) {
 	return &sessionCache{cache: cache}, nil
 }
 
+// Get returns a copy of the session token from the cache without signature
+// and context related fields. Returns nil if token is missing in the cache.
+// It is safe to modify and re-sign returned session token.
 func (c *sessionCache) Get(key string) *session.Token {
 	valueRaw, ok := c.cache.Get(key)
 	if !ok {
@@ -35,7 +38,13 @@ func (c *sessionCache) Get(key string) *session.Token {
 	value := valueRaw.(*cacheValue)
 	value.atime = time.Now()
 
-	return value.token
+	if value.token == nil {
+		return nil
+	}
+
+	res := copySessionTokenWithoutSignatureAndContext(*value.token)
+
+	return &res
 }
 
 func (c *sessionCache) GetAccessTime(key string) (time.Time, bool) {

--- a/pool/cache_test.go
+++ b/pool/cache_test.go
@@ -4,6 +4,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
+	"github.com/nspcc-dev/neofs-sdk-go/session"
+	sessiontest "github.com/nspcc-dev/neofs-sdk-go/session/test"
 	"github.com/stretchr/testify/require"
 )
 
@@ -28,4 +31,33 @@ func TestSessionCache_GetAccessTime(t *testing.T) {
 	t3, ok := cache.GetAccessTime(key)
 	require.True(t, ok)
 	require.NotEqual(t, t1, t3)
+}
+
+func TestSessionCache_GetUnmodifiedToken(t *testing.T) {
+	const key = "Foo"
+	target := sessiontest.Token()
+
+	pk, err := keys.NewPrivateKey()
+	require.NoError(t, err)
+
+	check := func(t *testing.T, tok *session.Token, extra string) {
+		require.Empty(t, tok.Signature().Sign(), extra)
+		require.Nil(t, tok.Context(), extra)
+	}
+
+	cache, err := newCache()
+	require.NoError(t, err)
+
+	cache.Put(key, target)
+	value := cache.Get(key)
+	check(t, value, "before sign")
+
+	err = value.Sign(&pk.PrivateKey)
+	require.NoError(t, err)
+
+	octx := sessiontest.ObjectContext()
+	value.SetContext(octx)
+
+	value = cache.Get(key)
+	check(t, value, "after sign")
 }

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -1582,3 +1582,30 @@ func newAddressFromCnrID(cnrID *cid.ID) *address.Address {
 	addr.SetContainerID(cnrID)
 	return addr
 }
+
+func copySessionTokenWithoutSignatureAndContext(from session.Token) (to session.Token) {
+	to.SetIat(from.Iat())
+	to.SetExp(from.Exp())
+	to.SetNbf(from.Nbf())
+
+	sessionTokenID := make([]byte, len(from.ID()))
+	copy(sessionTokenID, from.ID())
+	to.SetID(sessionTokenID)
+
+	sessionTokenKey := make([]byte, len(from.SessionKey()))
+	copy(sessionTokenKey, from.SessionKey())
+	to.SetSessionKey(sessionTokenKey)
+
+	var sessionTokenOwner owner.ID
+	buf, err := from.OwnerID().Marshal()
+	if err != nil {
+		panic(err) // should never happen
+	}
+	err = sessionTokenOwner.Unmarshal(buf)
+	if err != nil {
+		panic(err) // should never happen
+	}
+	to.SetOwnerID(&sessionTokenOwner)
+
+	return to
+}


### PR DESCRIPTION
Return copy of the session token from cache for safe re-signing operations.