### PR TITLE
client: Decode status at io.EOF in the client-side stream

### DIFF
--- a/client/object_put.go
+++ b/client/object_put.go
@@ -3,7 +3,9 @@ package client
 import (
 	"context"
 	"crypto/ecdsa"
+	"errors"
 	"fmt"
+	"io"
 
 	"github.com/nspcc-dev/neofs-api-go/v2/acl"
 	v2object "github.com/nspcc-dev/neofs-api-go/v2/object"
@@ -171,7 +173,10 @@ func (x *ObjectWriter) WritePayloadChunk(chunk []byte) bool {
 func (x *ObjectWriter) Close() (*ResObjectPut, error) {
 	defer x.cancelCtxStream()
 
-	if x.ctxCall.err != nil {
+	// Ignore io.EOF error, because it is expected error for client-side
+	// stream termination by the server. E.g. when stream contains invalid
+	// message. Server returns an error in response message (in status).
+	if x.ctxCall.err != nil && !errors.Is(x.ctxCall.err, io.EOF) {
 		return nil, x.ctxCall.err
 	}
 


### PR DESCRIPTION
Object service of NeoFS API contains one client-side stream method: object.Put. In client-side streams, server can return an error after processing stream message. In this case write method returns `io.EOF` and actual error reason is encoded in response status, which is obtained after `Close()`. Client library should process such case.

Related https://github.com/nspcc-dev/neofs-node/issues/1315