### PR TITLE
session: Add `container.IssuedBy` method

### DIFF
--- a/session/container.go
+++ b/session/container.go
@@ -376,3 +376,25 @@ func (x Container) AssertAuthKey(key neofscrypto.PublicKey) bool {
 
 	return bytes.Equal(bKey, x.body.GetSessionKey())
 }
+
+// IssuedBy returns true if session token is signed
+// and, therefore, owned by specified user.
+//
+// See also Sign.
+func (x Container) IssuedBy(id user.ID) bool {
+	var (
+		tokenOwner   user.ID
+		v2TokenOwner = x.body.GetOwnerID()
+	)
+
+	if v2TokenOwner == nil {
+		return false
+	}
+
+	err := tokenOwner.ReadFromV2(*v2TokenOwner)
+	if err != nil {
+		return false
+	}
+
+	return tokenOwner.Equals(id)
+}

--- a/session/container_test.go
+++ b/session/container_test.go
@@ -11,6 +11,7 @@ import (
 	cidtest "github.com/nspcc-dev/neofs-sdk-go/container/id/test"
 	"github.com/nspcc-dev/neofs-sdk-go/session"
 	sessiontest "github.com/nspcc-dev/neofs-sdk-go/session/test"
+	"github.com/nspcc-dev/neofs-sdk-go/user"
 	"github.com/stretchr/testify/require"
 )
 
@@ -284,4 +285,19 @@ func TestContainerSignature(t *testing.T) {
 		fs[i]()
 		require.True(t, x.VerifySignature())
 	}
+}
+
+func TestContainer_IssuedBy(t *testing.T) {
+	var (
+		token  session.Container
+		issuer user.ID
+		signer = randSigner()
+	)
+
+	user.IDFromKey(&issuer, signer.PublicKey)
+
+	require.False(t, token.IssuedBy(issuer))
+
+	require.NoError(t, token.Sign(signer))
+	require.True(t, token.IssuedBy(issuer))
 }


### PR DESCRIPTION
Required in S3 Gateway to [differentiate](https://github.com/nspcc-dev/neofs-s3-gw/blob/ea8e1b3b1987910602c2557855f173fdec8bb089/api/layer/layer.go#L634) `ErrBucketAlreadyOwnedByYou` and `ErrBucketAlreadyExists` errors.

Can be simple `Owner()` getter method, I suppose, but `session` package mostly have sugared methods in `Container`, so I did the same.