### PR TITLE
session: Add `CopyIssuer` method of `Container`

### DIFF
--- a/session/container.go
+++ b/session/container.go
@@ -377,24 +377,26 @@ func (x Container) AssertAuthKey(key neofscrypto.PublicKey) bool {
 	return bytes.Equal(bKey, x.body.GetSessionKey())
 }
 
-// IssuedBy returns true if session token is signed
-// and, therefore, owned by specified user.
+// Issuer returns user ID of the session issuer.
+//
+// Makes sense only for signed Container instances. For unsigned instances,
+// Issuer returns zero user.ID.
 //
 // See also Sign.
-func (x Container) IssuedBy(id user.ID) bool {
-	var (
-		tokenOwner   user.ID
-		v2TokenOwner = x.body.GetOwnerID()
-	)
+func (x Container) Issuer() user.ID {
+	var issuer user.ID
 
-	if v2TokenOwner == nil {
-		return false
+	issuerV2 := x.body.GetOwnerID()
+	if issuerV2 != nil {
+		_ = issuer.ReadFromV2(*issuerV2)
 	}
 
-	err := tokenOwner.ReadFromV2(*v2TokenOwner)
-	if err != nil {
-		return false
-	}
+	return issuer
+}
 
-	return tokenOwner.Equals(id)
+// IssuedBy checks if Container session is issued by the given user.
+//
+// See also Container.Issuer.
+func IssuedBy(cnr Container, id user.ID) bool {
+	return cnr.Issuer().Equals(id)
 }

--- a/session/container_test.go
+++ b/session/container_test.go
@@ -287,7 +287,7 @@ func TestContainerSignature(t *testing.T) {
 	}
 }
 
-func TestContainer_IssuedBy(t *testing.T) {
+func TestIssuedBy(t *testing.T) {
 	var (
 		token  session.Container
 		issuer user.ID
@@ -296,8 +296,23 @@ func TestContainer_IssuedBy(t *testing.T) {
 
 	user.IDFromKey(&issuer, signer.PublicKey)
 
-	require.False(t, token.IssuedBy(issuer))
+	require.False(t, session.IssuedBy(token, issuer))
 
 	require.NoError(t, token.Sign(signer))
-	require.True(t, token.IssuedBy(issuer))
+	require.True(t, session.IssuedBy(token, issuer))
+}
+
+func TestContainer_Issuer(t *testing.T) {
+	var token session.Container
+	signer := randSigner()
+
+	require.Zero(t, token.Issuer())
+
+	require.NoError(t, token.Sign(signer))
+
+	var issuer user.ID
+
+	user.IDFromKey(&issuer, signer.PublicKey)
+
+	require.True(t, token.Issuer().Equals(issuer))
 }


### PR DESCRIPTION
There is a need to duplicate session token owner, e.g. in container
created within the session.

Signed-off-by: Leonard Lyubich <leonard@nspcc.ru>