### PR TITLE
session: Add `Object.Issuer` method

### DIFF
--- a/session/object.go
+++ b/session/object.go
@@ -377,3 +377,20 @@ func (x Object) AssertAuthKey(key neofscrypto.PublicKey) bool {
 
 	return bytes.Equal(bKey, x.body.GetSessionKey())
 }
+
+// Issuer returns user ID of the session issuer.
+//
+// Makes sense only for signed Object instances. For unsigned instances,
+// Issuer returns zero user.ID.
+//
+// See also Sign.
+func (x Object) Issuer() user.ID {
+	var issuer user.ID
+
+	issuerV2 := x.body.GetOwnerID()
+	if issuerV2 != nil {
+		_ = issuer.ReadFromV2(*issuerV2)
+	}
+
+	return issuer
+}

--- a/session/object_test.go
+++ b/session/object_test.go
@@ -16,6 +16,7 @@ import (
 	addresstest "github.com/nspcc-dev/neofs-sdk-go/object/address/test"
 	"github.com/nspcc-dev/neofs-sdk-go/session"
 	sessiontest "github.com/nspcc-dev/neofs-sdk-go/session/test"
+	"github.com/nspcc-dev/neofs-sdk-go/user"
 	"github.com/stretchr/testify/require"
 )
 
@@ -293,4 +294,19 @@ func TestObjectSignature(t *testing.T) {
 		fs[i]()
 		require.True(t, x.VerifySignature())
 	}
+}
+
+func TestObject_Issuer(t *testing.T) {
+	var token session.Object
+	signer := randSigner()
+
+	require.Zero(t, token.Issuer())
+
+	require.NoError(t, token.Sign(signer))
+
+	var issuer user.ID
+
+	user.IDFromKey(&issuer, signer.PublicKey)
+
+	require.True(t, token.Issuer().Equals(issuer))
 }


### PR DESCRIPTION
Add method to get `Object` session's issuer similar to `Container`.

Signed-off-by: Leonard Lyubich <leonard@nspcc.ru>