### PR TITLE
Fix string encoding of identifiers

### DIFF
--- a/container/id/id_test.go
+++ b/container/id/id_test.go
@@ -64,7 +64,7 @@ func TestID_String(t *testing.T) {
 		id := cidtest.ID()
 		var id2 cid.ID
 
-		require.NoError(t, id2.DecodeString(id.String()))
+		require.NoError(t, id2.DecodeString(id.EncodeToString()))
 		require.Equal(t, id, id2)
 	})
 

--- a/eacl/filter.go
+++ b/eacl/filter.go
@@ -1,7 +1,6 @@
 package eacl
 
 import (
-	"fmt"
 	"strconv"
 
 	v2acl "github.com/nspcc-dev/neofs-api-go/v2/acl"
@@ -15,7 +14,7 @@ type Filter struct {
 	from    FilterHeaderType
 	matcher Match
 	key     filterKey
-	value   fmt.Stringer
+	value   stringEncoder
 }
 
 type staticStringer string
@@ -44,17 +43,17 @@ const (
 	fKeyObjHomomorphicHash
 )
 
-func (s staticStringer) String() string {
+func (s staticStringer) EncodeToString() string {
 	return string(s)
 }
 
-func (u u64Stringer) String() string {
+func (u u64Stringer) EncodeToString() string {
 	return strconv.FormatUint(uint64(u), 10)
 }
 
 // Value returns filtered string value.
 func (f Filter) Value() string {
-	return f.value.String()
+	return f.value.EncodeToString()
 }
 
 // Matcher returns filter Match type.
@@ -81,7 +80,7 @@ func (f *Filter) ToV2() *v2acl.HeaderFilter {
 	}
 
 	filter := new(v2acl.HeaderFilter)
-	filter.SetValue(f.value.String())
+	filter.SetValue(f.value.EncodeToString())
 	filter.SetKey(f.key.String())
 	filter.SetMatchType(f.matcher.ToV2())
 	filter.SetHeaderType(f.from.ToV2())

--- a/eacl/record_test.go
+++ b/eacl/record_test.go
@@ -177,17 +177,17 @@ func TestReservedRecords(t *testing.T) {
 		{
 			f:     func(r *Record) { r.AddObjectIDFilter(MatchStringEqual, oid) },
 			key:   v2acl.FilterObjectID,
-			value: oid.String(),
+			value: oid.EncodeToString(),
 		},
 		{
 			f:     func(r *Record) { r.AddObjectContainerIDFilter(MatchStringEqual, cid) },
 			key:   v2acl.FilterObjectContainerID,
-			value: cid.String(),
+			value: cid.EncodeToString(),
 		},
 		{
 			f:     func(r *Record) { r.AddObjectOwnerIDFilter(MatchStringEqual, ownerid) },
 			key:   v2acl.FilterObjectOwnerID,
-			value: ownerid.String(),
+			value: ownerid.EncodeToString(),
 		},
 		{
 			f:     func(r *Record) { r.AddObjectCreationEpoch(MatchStringEqual, 100) },

--- a/eacl/test/benchmark_test.go
+++ b/eacl/test/benchmark_test.go
@@ -95,7 +95,7 @@ func RecordN(n int) *eacl.Record {
 	x.SetTargets(*TargetN(n))
 
 	for i := 0; i < n; i++ {
-		x.AddFilter(eacl.HeaderFromObject, eacl.MatchStringEqual, "", cidtest.ID().String())
+		x.AddFilter(eacl.HeaderFromObject, eacl.MatchStringEqual, "", cidtest.ID().EncodeToString())
 	}
 
 	return x

--- a/ns/nns_test.go
+++ b/ns/nns_test.go
@@ -147,7 +147,7 @@ func TestNNS_ResolveContainerName(t *testing.T) {
 	t.Run("with container array element", func(t *testing.T) {
 		id := cidtest.ID()
 
-		arr[1] = stackitem.NewByteArray([]byte(id.String()))
+		arr[1] = stackitem.NewByteArray([]byte(id.EncodeToString()))
 
 		res, err := n.ResolveContainerName(testContainerName)
 		require.NoError(t, err)

--- a/object/id/id_test.go
+++ b/object/id/id_test.go
@@ -105,7 +105,7 @@ func TestID_String(t *testing.T) {
 				var oid ID
 
 				require.NoError(t, oid.DecodeString(str))
-				require.Equal(t, str, oid.String())
+				require.Equal(t, str, oid.EncodeToString())
 			})
 		}
 	})

--- a/object/search_test.go
+++ b/object/search_test.go
@@ -122,7 +122,7 @@ func TestSearchFilters_AddParentIDFilter(t *testing.T) {
 	require.Len(t, fsV2, 1)
 
 	require.Equal(t, v2object.FilterHeaderParent, fsV2[0].GetKey())
-	require.Equal(t, par.String(), fsV2[0].GetValue())
+	require.Equal(t, par.EncodeToString(), fsV2[0].GetValue())
 	require.Equal(t, v2object.MatchStringEqual, fsV2[0].GetMatchType())
 }
 
@@ -138,7 +138,7 @@ func TestSearchFilters_AddObjectIDFilter(t *testing.T) {
 		require.Len(t, fsV2, 1)
 
 		require.Equal(t, v2object.FilterHeaderObjectID, fsV2[0].GetKey())
-		require.Equal(t, id.String(), fsV2[0].GetValue())
+		require.Equal(t, id.EncodeToString(), fsV2[0].GetValue())
 		require.Equal(t, v2object.MatchStringEqual, fsV2[0].GetMatchType())
 	})
 }


### PR DESCRIPTION
Use `EncodeToString` method to get protocol string according to type
docs.

Signed-off-by: Leonard Lyubich <leonard@nspcc.ru>