### PR TITLE
Fix/SG's `out of range`

### DIFF
--- a/storagegroup/storagegroup.go
+++ b/storagegroup/storagegroup.go
@@ -138,14 +138,14 @@ func (sg *StorageGroup) SetMembers(members []oid.ID) {
 		if cap(mV2) >= ln {
 			mV2 = mV2[:0]
 		} else {
-			mV2 = make([]refs.ObjectID, ln)
+			mV2 = make([]refs.ObjectID, 0, ln)
 		}
 
 		var oidV2 refs.ObjectID
 
 		for i := 0; i < ln; i++ {
 			members[i].WriteToV2(&oidV2)
-			mV2[i] = oidV2
+			mV2 = append(mV2, oidV2)
 		}
 	}
 

--- a/storagegroup/storagegroup_test.go
+++ b/storagegroup/storagegroup_test.go
@@ -181,3 +181,15 @@ func generateOIDList() []refs.ObjectID {
 
 	return mmV2
 }
+
+func TestStorageGroup_SetMembers_DoubleSetting(t *testing.T) {
+	var sg storagegroup.StorageGroup
+
+	mm := []oid.ID{oidtest.ID(), oidtest.ID(), oidtest.ID()} // cap is 3 at least
+	sg.SetMembers(mm)
+
+	// the previous cap is more that a new length;
+	// slicing should not lead to `out of range`
+	// and apply update correctly
+	sg.SetMembers(mm[:1])
+}


### PR DESCRIPTION
It panicked when the previous members slice had capacity more than a new one
because of incorrect slicing that led to `out of range`.

Signed-off-by: Pavel Karpy <carpawell@nspcc.ru>