### PR TITLE
client: Fix response processing of Object.Put rpc

### DIFF
--- a/client/object_put.go
+++ b/client/object_put.go
@@ -187,7 +187,9 @@ func (x *ObjectWriter) Close() (*ResObjectPut, error) {
 		return nil, x.ctxCall.err
 	}
 
-	if !x.ctxCall.processResponse() {
+	x.ctxCall.processResponse()
+
+	if x.ctxCall.err != nil {
 		return nil, x.ctxCall.err
 	}
 


### PR DESCRIPTION
After 85e3c7b0870693fe025c5c46cabfb583d2bb5811 `processResponse` method
sets `err` field or sets status in `statusRes` field of `contextCall`.
In previous implementation `ObjectWriter.Close` method returned
`ctxCall.err` on `false` return of `processResponse` method. This could
cause NPE-panic if status failure resolving was disabled.

Make `ObjectWriter.Close` to return internal `err` field only if it is
set, otherwise return status response.

Signed-off-by: Leonard Lyubich <leonard@nspcc.ru>

* issue for test coverage #270