### PR TITLE
container: Remove session token and signature from Container/eACL

### DIFF
--- a/container/container.go
+++ b/container/container.go
@@ -9,19 +9,13 @@ import (
 	"github.com/nspcc-dev/neofs-api-go/v2/refs"
 	"github.com/nspcc-dev/neofs-sdk-go/acl"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
-	neofscrypto "github.com/nspcc-dev/neofs-sdk-go/crypto"
 	"github.com/nspcc-dev/neofs-sdk-go/netmap"
-	"github.com/nspcc-dev/neofs-sdk-go/session"
 	"github.com/nspcc-dev/neofs-sdk-go/user"
 	"github.com/nspcc-dev/neofs-sdk-go/version"
 )
 
 type Container struct {
 	v2 container.Container
-
-	token *session.Container
-
-	sig *neofscrypto.Signature
 }
 
 // New creates, initializes and returns blank Container instance.
@@ -183,28 +177,6 @@ func (c *Container) SetPlacementPolicy(v *netmap.PlacementPolicy) {
 	}
 
 	c.v2.SetPlacementPolicy(m)
-}
-
-// SessionToken returns token of the session within
-// which container was created.
-func (c Container) SessionToken() *session.Container {
-	return c.token
-}
-
-// SetSessionToken sets token of the session within
-// which container was created.
-func (c *Container) SetSessionToken(t *session.Container) {
-	c.token = t
-}
-
-// Signature returns signature of the marshaled container.
-func (c Container) Signature() *neofscrypto.Signature {
-	return c.sig
-}
-
-// SetSignature sets signature of the marshaled container.
-func (c *Container) SetSignature(sig *neofscrypto.Signature) {
-	c.sig = sig
 }
 
 // Marshal marshals Container into a protobuf binary form.

--- a/container/container_test.go
+++ b/container/container_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/nspcc-dev/neofs-sdk-go/container"
 	containertest "github.com/nspcc-dev/neofs-sdk-go/container/test"
 	netmaptest "github.com/nspcc-dev/neofs-sdk-go/netmap/test"
-	sessiontest "github.com/nspcc-dev/neofs-sdk-go/session/test"
 	usertest "github.com/nspcc-dev/neofs-sdk-go/user/test"
 	"github.com/nspcc-dev/neofs-sdk-go/version"
 	versiontest "github.com/nspcc-dev/neofs-sdk-go/version/test"
@@ -75,16 +74,6 @@ func TestContainerEncoding(t *testing.T) {
 	})
 }
 
-func TestContainer_SessionToken(t *testing.T) {
-	tok := sessiontest.Container()
-
-	cnr := container.New()
-
-	cnr.SetSessionToken(tok)
-
-	require.Equal(t, tok, cnr.SessionToken())
-}
-
 func TestContainer_ToV2(t *testing.T) {
 	t.Run("nil", func(t *testing.T) {
 		var x *container.Container
@@ -96,8 +85,6 @@ func TestContainer_ToV2(t *testing.T) {
 		cnt := container.New()
 
 		// check initial values
-		require.Nil(t, cnt.SessionToken())
-		require.Nil(t, cnt.Signature())
 		require.Nil(t, cnt.Attributes())
 		require.Nil(t, cnt.PlacementPolicy())
 		require.Nil(t, cnt.OwnerID())

--- a/eacl/table.go
+++ b/eacl/table.go
@@ -7,8 +7,6 @@ import (
 	v2acl "github.com/nspcc-dev/neofs-api-go/v2/acl"
 	"github.com/nspcc-dev/neofs-api-go/v2/refs"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
-	neofscrypto "github.com/nspcc-dev/neofs-sdk-go/crypto"
-	"github.com/nspcc-dev/neofs-sdk-go/session"
 	"github.com/nspcc-dev/neofs-sdk-go/version"
 )
 
@@ -18,8 +16,6 @@ import (
 type Table struct {
 	version version.Version
 	cid     *cid.ID
-	token   *session.Container
-	sig     *neofscrypto.Signature
 	records []Record
 }
 
@@ -58,28 +54,6 @@ func (t *Table) AddRecord(r *Record) {
 	if r != nil {
 		t.records = append(t.records, *r)
 	}
-}
-
-// SessionToken returns token of the session
-// within which Table was set.
-func (t Table) SessionToken() *session.Container {
-	return t.token
-}
-
-// SetSessionToken sets token of the session
-// within which Table was set.
-func (t *Table) SetSessionToken(tok *session.Container) {
-	t.token = tok
-}
-
-// Signature returns Table signature.
-func (t Table) Signature() *neofscrypto.Signature {
-	return t.sig
-}
-
-// SetSignature sets Table signature.
-func (t *Table) SetSignature(sig *neofscrypto.Signature) {
-	t.sig = sig
 }
 
 // ToV2 converts Table to v2 acl.EACLTable message.

--- a/eacl/table_test.go
+++ b/eacl/table_test.go
@@ -8,7 +8,6 @@ import (
 	cidtest "github.com/nspcc-dev/neofs-sdk-go/container/id/test"
 	"github.com/nspcc-dev/neofs-sdk-go/eacl"
 	eacltest "github.com/nspcc-dev/neofs-sdk-go/eacl/test"
-	sessiontest "github.com/nspcc-dev/neofs-sdk-go/session/test"
 	"github.com/nspcc-dev/neofs-sdk-go/version"
 	"github.com/stretchr/testify/require"
 )
@@ -92,15 +91,6 @@ func TestTableEncoding(t *testing.T) {
 	})
 }
 
-func TestTable_SessionToken(t *testing.T) {
-	tok := sessiontest.Container()
-
-	table := eacl.NewTable()
-	table.SetSessionToken(tok)
-
-	require.Equal(t, tok, table.SessionToken())
-}
-
 func TestTable_ToV2(t *testing.T) {
 	t.Run("nil", func(t *testing.T) {
 		var x *eacl.Table
@@ -116,8 +106,6 @@ func TestTable_ToV2(t *testing.T) {
 		require.Nil(t, table.Records())
 		_, set := table.CID()
 		require.False(t, set)
-		require.Nil(t, table.SessionToken())
-		require.Nil(t, table.Signature())
 
 		// convert to v2 message
 		tableV2 := table.ToV2()


### PR DESCRIPTION
Session token and signature isn't presented in `Container` and
`EACLTable` messages of NeoFS API V2 protocol. These entities are needed
for access control and doesn't carry payload of these messages.

Remove `SetSessionToken` / `SessionToken` methods of
`container.Container` and `eacl.Table` types. Provide methods to specify
these components in corresponding `Client` operations.

Signed-off-by: Leonard Lyubich <leonard@nspcc.ru>