### PR TITLE
netmap: allow more uint64 config values

### DIFF
--- a/netmap/network_info.go
+++ b/netmap/network_info.go
@@ -257,12 +257,19 @@ func (x *NetworkInfo) setConfigUint64(name string, num uint64) {
 	x.setConfig(name, val)
 }
 
+// decodeConfigValueUint64 parses val as little-endian uint64.
+// val must be less than 8 bytes in size.
 func decodeConfigValueUint64(val []byte) (uint64, error) {
-	if ln := len(val); ln != 8 {
+	if ln := len(val); ln > 8 {
 		return 0, fmt.Errorf("invalid uint64 parameter length %d", ln)
 	}
 
-	return binary.LittleEndian.Uint64(val), nil
+	res := uint64(0)
+	for i := len(val) - 1; i >= 0; i-- {
+		res = res*256 + uint64(val[i])
+	}
+
+	return res, nil
 }
 
 func (x NetworkInfo) configUint64(name string) uint64 {

--- a/netmap/network_info_decode_test.go
+++ b/netmap/network_info_decode_test.go
@@ -1,0 +1,28 @@
+package netmap
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/nspcc-dev/neo-go/pkg/encoding/bigint"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecodeUint64(t *testing.T) {
+	testCases := []uint64{
+		0,
+		12,
+		129,
+		0x1234,
+		0x12345678,
+		0x1234567891011,
+	}
+
+	for _, expected := range testCases {
+		val := bigint.ToBytes(big.NewInt(int64(expected)))
+
+		actual, err := decodeConfigValueUint64(val)
+		require.NoError(t, err)
+		require.Equal(t, expected, actual)
+	}
+}


### PR DESCRIPTION
NEO VM uses little-endian format for integers,
however the resulting byte slice can contain less than 8 bytes.

Signed-off-by: Evgenii Stratonikov <evgeniy@nspcc.ru>