### PR TITLE
policy: Remove error listeners from query lexer

### DIFF
--- a/netmap/policy.go
+++ b/netmap/policy.go
@@ -551,15 +551,16 @@ func writeFilterStringTo(w io.StringWriter, f netmap.Filter) error {
 // DecodeString decodes PlacementPolicy from the string composed using
 // WriteStringTo. Returns error if s is malformed.
 func (p *PlacementPolicy) DecodeString(s string) error {
+	var v policyVisitor
+
 	input := antlr.NewInputStream(s)
 	lexer := parser.NewQueryLexer(input)
 	lexer.RemoveErrorListeners()
+	lexer.AddErrorListener(&v)
 	stream := antlr.NewCommonTokenStream(lexer, 0)
 
 	pp := parser.NewQuery(stream)
 	pp.BuildParseTrees = true
-
-	var v policyVisitor
 
 	pp.RemoveErrorListeners()
 	pp.AddErrorListener(&v)

--- a/netmap/policy.go
+++ b/netmap/policy.go
@@ -553,6 +553,7 @@ func writeFilterStringTo(w io.StringWriter, f netmap.Filter) error {
 func (p *PlacementPolicy) DecodeString(s string) error {
 	input := antlr.NewInputStream(s)
 	lexer := parser.NewQueryLexer(input)
+	lexer.RemoveErrorListeners()
 	stream := antlr.NewCommonTokenStream(lexer, 0)
 
 	pp := parser.NewQuery(stream)

--- a/netmap/policy_test.go
+++ b/netmap/policy_test.go
@@ -25,8 +25,9 @@ SELECT 1 IN City FROM SPBSSD AS SPB
 FILTER City EQ SPB AND SSD EQ true OR City EQ SPB AND Rating GE 5 AS SPBSSD`,
 	}
 
+	var p PlacementPolicy
+
 	for _, testCase := range testCases {
-		var p PlacementPolicy
 
 		require.NoError(t, p.DecodeString(testCase))
 
@@ -34,6 +35,14 @@ FILTER City EQ SPB AND SSD EQ true OR City EQ SPB AND Rating GE 5 AS SPBSSD`,
 		require.NoError(t, p.WriteStringTo(&b))
 
 		require.Equal(t, testCase, b.String())
+	}
+
+	invalidTestCases := []string{
+		`?REP 1`,
+	}
+
+	for i := range invalidTestCases {
+		require.Error(t, p.DecodeString(invalidTestCases[i]), "#%d", i)
 	}
 }
 


### PR DESCRIPTION
In previous implementation `PlacementPolicy.DecodeString` produced
undesired console logs.

Signed-off-by: Leonard Lyubich <leonard@nspcc.ru>

* closes #280