### PR TITLE
client: Do not use pointers to required response fields

### DIFF
--- a/client/common.go
+++ b/client/common.go
@@ -251,7 +251,7 @@ func (x *contextCall) close() bool {
 		x.result(x.resp)
 	}
 
-	return true
+	return x.err == nil
 }
 
 // goes through all stages of sending a request and processing a response. Returns true if successful.

--- a/client/errors.go
+++ b/client/errors.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"errors"
+	"fmt"
 
 	apistatus "github.com/nspcc-dev/neofs-sdk-go/client/status"
 )
@@ -91,4 +92,15 @@ func IsErrSessionNotFound(err error) bool {
 		*apistatus.SessionTokenNotFound:
 		return true
 	}
+}
+
+// returns error describing missing field with the given name.
+func newErrMissingResponseField(name string) error {
+	return fmt.Errorf("missing %s field in the response", name)
+}
+
+// returns error describing invalid field (according to the NeoFS protocol)
+// with the given name and format violation err.
+func newErrInvalidResponseField(name string, err error) error {
+	return fmt.Errorf("invalid %s field in the response: %w", name, err)
 }

--- a/client/object_hash.go
+++ b/client/object_hash.go
@@ -195,6 +195,9 @@ func (c *Client) ObjectHash(ctx context.Context, prm PrmObjectHash) (*ResObjectH
 	}
 	cc.result = func(r responseV2) {
 		res.checksums = r.(*v2object.GetRangeHashResponse).GetBody().GetHashList()
+		if len(res.checksums) == 0 {
+			cc.err = newErrMissingResponseField("hash list")
+		}
 	}
 
 	// process call

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/nspcc-dev/neo-go/pkg/crypto/keys"
 	apistatus "github.com/nspcc-dev/neofs-sdk-go/client/status"
+	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	neofsecdsa "github.com/nspcc-dev/neofs-sdk-go/crypto/ecdsa"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
 	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
@@ -479,7 +480,9 @@ func TestWaitPresence(t *testing.T) {
 			cancel()
 		}()
 
-		err := waitForContainerPresence(ctx, mockCli, nil, &WaitParams{
+		var idCnr cid.ID
+
+		err := waitForContainerPresence(ctx, mockCli, idCnr, &WaitParams{
 			timeout:      120 * time.Second,
 			pollInterval: 5 * time.Second,
 		})
@@ -489,7 +492,8 @@ func TestWaitPresence(t *testing.T) {
 
 	t.Run("context deadline exceeded", func(t *testing.T) {
 		ctx := context.Background()
-		err := waitForContainerPresence(ctx, mockCli, nil, &WaitParams{
+		var idCnr cid.ID
+		err := waitForContainerPresence(ctx, mockCli, idCnr, &WaitParams{
 			timeout:      500 * time.Millisecond,
 			pollInterval: 5 * time.Second,
 		})
@@ -499,7 +503,8 @@ func TestWaitPresence(t *testing.T) {
 
 	t.Run("ok", func(t *testing.T) {
 		ctx := context.Background()
-		err := waitForContainerPresence(ctx, mockCli, nil, &WaitParams{
+		var idCnr cid.ID
+		err := waitForContainerPresence(ctx, mockCli, idCnr, &WaitParams{
 			timeout:      10 * time.Second,
 			pollInterval: 500 * time.Millisecond,
 		})


### PR DESCRIPTION
In previous implementation `client` package provided access to nested
response fields as pointers to them. This caused clients to handle nil
cases even when the field presence in the response is required.

Avoid returning pointers to required fields in response getters. This
also reduces reference counter load and allows fields to be decoded
directly without additional assignment.

Signed-off-by: Leonard Lyubich <leonard@nspcc.ru>

* closes #299

I decided to not make changes compatible and just change the return type.