### PR TITLE
client: Fix processing of the Object PUT failed response

### DIFF
--- a/client/object_put.go
+++ b/client/object_put.go
@@ -179,7 +179,7 @@ func (x *ObjectWriter) Close() (*ResObjectPut, error) {
 		return nil, x.ctxCall.err
 	}
 
-	if !x.ctxCall.close() {
+	if x.ctxCall.err = x.ctxCall.closer(); x.ctxCall.err != nil {
 		return nil, x.ctxCall.err
 	}
 


### PR DESCRIPTION
In previous implementation `ObjectWrite.Close` called `close` method
which in turn called `result` callback. Thus failed statuses could lead
to false-positive result processing.

Replace calling `close` method with direct `closer` method's call in
`ObjectWrite.Close` directly.

Signed-off-by: Leonard Lyubich <leonard@nspcc.ru>

* closes #317