### PR TITLE
Fix object put

### DIFF
--- a/client/object_put.go
+++ b/client/object_put.go
@@ -189,6 +189,13 @@ func (x *ObjectWriter) Close() (*ResObjectPut, error) {
 		return nil, x.ctxCall.err
 	}
 
+	if x.ctxCall.result != nil {
+		x.ctxCall.result(x.ctxCall.resp)
+		if x.ctxCall.err != nil {
+			return nil, x.ctxCall.err
+		}
+	}
+
 	return x.ctxCall.statusRes.(*ResObjectPut), nil
 }
 


### PR DESCRIPTION
Fix #320 .

@cthulhu-rider could you tell a bit more about the commit message? It seems like `close` calls `closer` and returns the error, what was the problem?

This reverts commit f8148c954bf26d2f228b9ec16282d80b062328f8.

Anyway, let's merge this to fix `neofs-cli object put` on master an fix the issue later.