### PR TITLE
Simplify object client methods

### DIFF
--- a/client/common.go
+++ b/client/common.go
@@ -288,11 +288,6 @@ func (x *contextCall) processCall() bool {
 // initializes static cross-call parameters inherited from client.
 func (c *Client) initCallContext(ctx *contextCall) {
 	ctx.key = c.prm.key
-	c.initCallContextWithoutKey(ctx)
-}
-
-// initializes static cross-call parameters inherited from client except private key.
-func (c *Client) initCallContextWithoutKey(ctx *contextCall) {
 	ctx.resolveAPIFailures = c.prm.resolveNeoFSErrors
 	ctx.callbackResp = c.prm.cbRespInfo
 	ctx.netMagic = c.prm.netMagic

--- a/client/common.go
+++ b/client/common.go
@@ -52,19 +52,6 @@ func (x *prmCommonMeta) WithXHeaders(hs ...string) {
 	x.xHeaders = hs
 }
 
-func (x prmCommonMeta) writeToMetaHeader(h *v2session.RequestMetaHeader) {
-	if len(x.xHeaders) > 0 {
-		hs := make([]v2session.XHeader, len(x.xHeaders)/2)
-
-		for i := 0; i < len(x.xHeaders); i += 2 {
-			hs[i].SetKey(x.xHeaders[i])
-			hs[i].SetValue(x.xHeaders[i+1])
-		}
-
-		h.SetXHeaders(hs)
-	}
-}
-
 func writeXHeadersToMeta(xHeaders []string, h *v2session.RequestMetaHeader) {
 	if len(xHeaders) == 0 {
 		return
@@ -166,7 +153,7 @@ func (x contextCall) prepareRequest() {
 
 	meta.SetNetworkMagic(x.netMagic)
 
-	x.meta.writeToMetaHeader(meta)
+	writeXHeadersToMeta(x.meta.xHeaders, meta)
 }
 
 func (c *Client) prepareRequest(req request, meta *v2session.RequestMetaHeader) {

--- a/client/common.go
+++ b/client/common.go
@@ -69,6 +69,7 @@ func (x prmCommonMeta) writeToMetaHeader(h *v2session.RequestMetaHeader) {
 const (
 	panicMsgMissingContext   = "missing context"
 	panicMsgMissingContainer = "missing container"
+	panicMsgMissingObject    = "missing object"
 )
 
 // groups all the details required to send a single request and process a response to it.

--- a/client/common.go
+++ b/client/common.go
@@ -57,6 +57,10 @@ func writeXHeadersToMeta(xHeaders []string, h *v2session.RequestMetaHeader) {
 		return
 	}
 
+	if len(xHeaders)%2 != 0 {
+		panic("slice of X-Headers with odd length")
+	}
+
 	hs := make([]v2session.XHeader, len(xHeaders)/2)
 	for i := 0; i < len(xHeaders); i += 2 {
 		hs[i].SetKey(xHeaders[i])

--- a/client/container.go
+++ b/client/container.go
@@ -114,7 +114,7 @@ func (c *Client) ContainerPut(ctx context.Context, prm PrmContainerPut) (*ResCon
 
 	// form meta header
 	var meta v2session.RequestMetaHeader
-	prm.prmCommonMeta.writeToMetaHeader(&meta)
+	writeXHeadersToMeta(prm.prmCommonMeta.xHeaders, &meta)
 
 	if prm.sessionSet {
 		var tokv2 v2session.Token
@@ -456,7 +456,7 @@ func (c *Client) ContainerDelete(ctx context.Context, prm PrmContainerDelete) (*
 
 	// form meta header
 	var meta v2session.RequestMetaHeader
-	prm.prmCommonMeta.writeToMetaHeader(&meta)
+	writeXHeadersToMeta(prm.prmCommonMeta.xHeaders, &meta)
 
 	if prm.tokSet {
 		var tokv2 v2session.Token
@@ -677,7 +677,7 @@ func (c *Client) ContainerSetEACL(ctx context.Context, prm PrmContainerSetEACL) 
 
 	// form meta header
 	var meta v2session.RequestMetaHeader
-	prm.prmCommonMeta.writeToMetaHeader(&meta)
+	writeXHeadersToMeta(prm.prmCommonMeta.xHeaders, &meta)
 
 	if prm.sessionSet {
 		var tokv2 v2session.Token

--- a/client/object_delete.go
+++ b/client/object_delete.go
@@ -85,10 +85,6 @@ func (x *PrmObjectDelete) UseKey(key ecdsa.PrivateKey) {
 //
 // Slice must not be mutated until the operation completes.
 func (x *PrmObjectDelete) WithXHeaders(hs ...string) {
-	if len(hs)%2 != 0 {
-		panic("slice of X-Headers with odd length")
-	}
-
 	writeXHeadersToMeta(hs, &x.meta)
 }
 

--- a/client/object_delete.go
+++ b/client/object_delete.go
@@ -131,7 +131,7 @@ func (c *Client) ObjectDelete(ctx context.Context, prm PrmObjectDelete) (*ResObj
 	case prm.addr.GetContainerID() == nil:
 		panic(panicMsgMissingContainer)
 	case prm.addr.GetObjectID() == nil:
-		panic("missing object")
+		panic(panicMsgMissingObject)
 	}
 
 	// form request body

--- a/client/object_delete.go
+++ b/client/object_delete.go
@@ -86,7 +86,7 @@ func (x *PrmObjectDelete) WithXHeaders(hs ...string) {
 		panic("slice of X-Headers with odd length")
 	}
 
-	prmCommonMeta{xHeaders: hs}.writeToMetaHeader(&x.meta)
+	writeXHeadersToMeta(hs, &x.meta)
 }
 
 // ResObjectDelete groups resulting values of ObjectDelete operation.

--- a/client/object_delete.go
+++ b/client/object_delete.go
@@ -148,11 +148,9 @@ func (c *Client) ObjectDelete(ctx context.Context, prm PrmObjectDelete) (*ResObj
 		res ResObjectDelete
 	)
 
+	c.initCallContext(&cc)
 	if prm.keySet {
-		c.initCallContextWithoutKey(&cc)
 		cc.key = prm.key
-	} else {
-		c.initCallContext(&cc)
 	}
 
 	cc.req = &req

--- a/client/object_get.go
+++ b/client/object_get.go
@@ -36,10 +36,6 @@ type prmObjectRead struct {
 //
 // Slice must not be mutated until the operation completes.
 func (x *prmObjectRead) WithXHeaders(hs ...string) {
-	if len(hs)%2 != 0 {
-		panic("slice of X-Headers with odd length")
-	}
-
 	writeXHeadersToMeta(hs, &x.meta)
 }
 

--- a/client/object_get.go
+++ b/client/object_get.go
@@ -499,11 +499,9 @@ func (c *Client) ObjectHead(ctx context.Context, prm PrmObjectHead) (*ResObjectH
 
 	res.idObj = prm.objID
 
+	c.initCallContext(&cc)
 	if prm.keySet {
-		c.initCallContextWithoutKey(&cc)
 		cc.key = prm.key
-	} else {
-		c.initCallContext(&cc)
 	}
 
 	cc.req = &req

--- a/client/object_get.go
+++ b/client/object_get.go
@@ -319,7 +319,7 @@ func (c *Client) ObjectGetInit(ctx context.Context, prm PrmObjectGet) (*ObjectRe
 	case !prm.cnrSet:
 		panic(panicMsgMissingContainer)
 	case !prm.objSet:
-		panic("missing object")
+		panic(panicMsgMissingObject)
 	}
 
 	var (
@@ -458,7 +458,7 @@ func (c *Client) ObjectHead(ctx context.Context, prm PrmObjectHead) (*ResObjectH
 	case !prm.cnrSet:
 		panic(panicMsgMissingContainer)
 	case !prm.objSet:
-		panic("missing object")
+		panic(panicMsgMissingObject)
 	}
 
 	var (
@@ -729,7 +729,7 @@ func (c *Client) ObjectRangeInit(ctx context.Context, prm PrmObjectRange) (*Obje
 	case !prm.cnrSet:
 		panic(panicMsgMissingContainer)
 	case !prm.objSet:
-		panic("missing object")
+		panic(panicMsgMissingObject)
 	case prm.ln == 0:
 		panic("zero range length")
 	}

--- a/client/object_get.go
+++ b/client/object_get.go
@@ -60,7 +60,7 @@ func (x prmObjectRead) writeToMetaHeader(h *v2session.RequestMetaHeader) {
 		h.SetSessionToken(&tokv2)
 	}
 
-	x.prmCommonMeta.writeToMetaHeader(h)
+	writeXHeadersToMeta(x.prmCommonMeta.xHeaders, h)
 }
 
 // MarkRaw marks an intent to read physically stored object.

--- a/client/object_hash.go
+++ b/client/object_hash.go
@@ -161,7 +161,7 @@ func (c *Client) ObjectHash(ctx context.Context, prm PrmObjectHash) (*ResObjectH
 	case prm.addr.GetContainerID() == nil:
 		panic(panicMsgMissingContainer)
 	case prm.addr.GetObjectID() == nil:
-		panic("missing object")
+		panic(panicMsgMissingObject)
 	case len(prm.body.GetRanges()) == 0:
 		panic("missing ranges")
 	}

--- a/client/object_hash.go
+++ b/client/object_hash.go
@@ -24,7 +24,7 @@ type PrmObjectHash struct {
 
 	body v2object.GetRangeHashRequestBody
 
-	tillichZemor bool
+	csAlgo v2refs.ChecksumType
 
 	addr v2refs.Address
 }
@@ -101,7 +101,7 @@ func (x *PrmObjectHash) SetRangeList(r ...uint64) {
 //
 // By default, SHA256 hash function is used.
 func (x *PrmObjectHash) TillichZemorAlgo() {
-	x.tillichZemor = true
+	x.csAlgo = v2refs.TillichZemor
 }
 
 // UseSalt sets the salt to XOR the data range before hashing.
@@ -170,10 +170,10 @@ func (c *Client) ObjectHash(ctx context.Context, prm PrmObjectHash) (*ResObjectH
 	}
 
 	prm.body.SetAddress(&prm.addr)
-	if prm.tillichZemor {
-		prm.body.SetType(v2refs.TillichZemor)
-	} else {
+	if prm.csAlgo == v2refs.UnknownChecksum {
 		prm.body.SetType(v2refs.SHA256)
+	} else {
+		prm.body.SetType(prm.csAlgo)
 	}
 
 	var req v2object.GetRangeHashRequest

--- a/client/object_hash.go
+++ b/client/object_hash.go
@@ -116,10 +116,6 @@ func (x *PrmObjectHash) UseSalt(salt []byte) {
 //
 // Slice must not be mutated until the operation completes.
 func (x *PrmObjectHash) WithXHeaders(hs ...string) {
-	if len(hs)%2 != 0 {
-		panic("slice of X-Headers with odd length")
-	}
-
 	writeXHeadersToMeta(hs, &x.meta)
 }
 

--- a/client/object_put.go
+++ b/client/object_put.go
@@ -12,7 +12,9 @@ import (
 	rpcapi "github.com/nspcc-dev/neofs-api-go/v2/rpc"
 	"github.com/nspcc-dev/neofs-api-go/v2/rpc/client"
 	v2session "github.com/nspcc-dev/neofs-api-go/v2/session"
+	"github.com/nspcc-dev/neofs-api-go/v2/signature"
 	"github.com/nspcc-dev/neofs-sdk-go/bearer"
+	apistatus "github.com/nspcc-dev/neofs-sdk-go/client/status"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
 	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	"github.com/nspcc-dev/neofs-sdk-go/session"
@@ -21,6 +23,8 @@ import (
 // PrmObjectPutInit groups parameters of ObjectPutInit operation.
 type PrmObjectPutInit struct {
 	copyNum uint32
+	key     *ecdsa.PrivateKey
+	meta    v2session.RequestMetaHeader
 }
 
 // SetCopiesNumber sets number of object copies that is enough to consider put successful.
@@ -47,57 +51,62 @@ func (x ResObjectPut) StoredObjectID() oid.ID {
 type ObjectWriter struct {
 	cancelCtxStream context.CancelFunc
 
-	ctxCall contextCall
+	client *Client
+	stream interface {
+		Write(*v2object.PutRequest) error
+		Close() error
+	}
 
-	// initially bound tp contextCall
-	metaHdr v2session.RequestMetaHeader
-
-	// initially bound to contextCall
-	partInit v2object.PutObjectPartInit
+	key *ecdsa.PrivateKey
+	res ResObjectPut
+	err error
 
 	chunkCalled bool
 
+	respV2    v2object.PutResponse
+	req       v2object.PutRequest
+	partInit  v2object.PutObjectPartInit
 	partChunk v2object.PutObjectPartChunk
 }
 
 // UseKey specifies private key to sign the requests.
 // If key is not provided, then Client default key is used.
-func (x *ObjectWriter) UseKey(key ecdsa.PrivateKey) {
-	x.ctxCall.key = key
+func (x *PrmObjectPutInit) UseKey(key ecdsa.PrivateKey) {
+	x.key = &key
 }
 
 // WithBearerToken attaches bearer token to be used for the operation.
 // Should be called once before any writing steps.
-func (x *ObjectWriter) WithBearerToken(t bearer.Token) {
+func (x *PrmObjectPutInit) WithBearerToken(t bearer.Token) {
 	var v2token acl.BearerToken
 	t.WriteToV2(&v2token)
-	x.metaHdr.SetBearerToken(&v2token)
+	x.meta.SetBearerToken(&v2token)
 }
 
 // WithinSession specifies session within which object should be stored.
 // Should be called once before any writing steps.
-func (x *ObjectWriter) WithinSession(t session.Object) {
+func (x *PrmObjectPutInit) WithinSession(t session.Object) {
 	var tv2 v2session.Token
 	t.WriteToV2(&tv2)
 
-	x.metaHdr.SetSessionToken(&tv2)
+	x.meta.SetSessionToken(&tv2)
 }
 
 // MarkLocal tells the server to execute the operation locally.
-func (x *ObjectWriter) MarkLocal() {
-	x.metaHdr.SetTTL(1)
+func (x *PrmObjectPutInit) MarkLocal() {
+	x.meta.SetTTL(1)
 }
 
 // WithXHeaders specifies list of extended headers (string key-value pairs)
 // to be attached to the request. Must have an even length.
 //
 // Slice must not be mutated until the operation completes.
-func (x *ObjectWriter) WithXHeaders(hs ...string) {
+func (x *PrmObjectPutInit) WithXHeaders(hs ...string) {
 	if len(hs)%2 != 0 {
 		panic("slice of X-Headers with odd length")
 	}
 
-	writeXHeadersToMeta(hs, &x.metaHdr)
+	writeXHeadersToMeta(hs, &x.meta)
 }
 
 // WriteHeader writes header of the object. Result means success.
@@ -109,7 +118,17 @@ func (x *ObjectWriter) WriteHeader(hdr object.Object) bool {
 	x.partInit.SetHeader(v2Hdr.GetHeader())
 	x.partInit.SetSignature(v2Hdr.GetSignature())
 
-	return x.ctxCall.writeRequest()
+	x.req.GetBody().SetObjectPart(&x.partInit)
+	x.req.SetVerificationHeader(nil)
+
+	x.err = signature.SignServiceMessage(x.key, &x.req)
+	if x.err != nil {
+		x.err = fmt.Errorf("sign message: %w", x.err)
+		return false
+	}
+
+	x.err = x.stream.Write(&x.req)
+	return x.err == nil
 }
 
 // WritePayloadChunk writes chunk of the object payload. Result means success.
@@ -117,7 +136,7 @@ func (x *ObjectWriter) WriteHeader(hdr object.Object) bool {
 func (x *ObjectWriter) WritePayloadChunk(chunk []byte) bool {
 	if !x.chunkCalled {
 		x.chunkCalled = true
-		x.ctxCall.req.(*v2object.PutRequest).GetBody().SetObjectPart(&x.partChunk)
+		x.req.GetBody().SetObjectPart(&x.partChunk)
 	}
 
 	for ln := len(chunk); ln > 0; ln = len(chunk) {
@@ -142,8 +161,16 @@ func (x *ObjectWriter) WritePayloadChunk(chunk []byte) bool {
 		// It is mentally assumed that allocating and filling the buffer is better than
 		// synchronous sending, but this needs to be tested.
 		x.partChunk.SetChunk(chunk[:ln])
+		x.req.SetVerificationHeader(nil)
 
-		if !x.ctxCall.writeRequest() {
+		x.err = signature.SignServiceMessage(x.key, &x.req)
+		if x.err != nil {
+			x.err = fmt.Errorf("sign message: %w", x.err)
+			return false
+		}
+
+		x.err = x.stream.Write(&x.req)
+		if x.err != nil {
 			return false
 		}
 
@@ -175,28 +202,36 @@ func (x *ObjectWriter) Close() (*ResObjectPut, error) {
 	// Ignore io.EOF error, because it is expected error for client-side
 	// stream termination by the server. E.g. when stream contains invalid
 	// message. Server returns an error in response message (in status).
-	if x.ctxCall.err != nil && !errors.Is(x.ctxCall.err, io.EOF) {
-		return nil, x.ctxCall.err
+	if x.err != nil && !errors.Is(x.err, io.EOF) {
+		return nil, x.err
 	}
 
-	if x.ctxCall.err = x.ctxCall.closer(); x.ctxCall.err != nil {
-		return nil, x.ctxCall.err
+	if x.err = x.stream.Close(); x.err != nil {
+		return nil, x.err
 	}
 
-	x.ctxCall.processResponse()
-
-	if x.ctxCall.err != nil {
-		return nil, x.ctxCall.err
+	x.res.st, x.err = x.client.processResponse(&x.respV2)
+	if x.err != nil {
+		return nil, x.err
 	}
 
-	if x.ctxCall.result != nil {
-		x.ctxCall.result(x.ctxCall.resp)
-		if x.ctxCall.err != nil {
-			return nil, x.ctxCall.err
-		}
+	if !apistatus.IsSuccessful(x.res.st) {
+		return &x.res, nil
 	}
 
-	return x.ctxCall.statusRes.(*ResObjectPut), nil
+	const fieldID = "ID"
+
+	idV2 := x.respV2.GetBody().GetObjectID()
+	if idV2 == nil {
+		return nil, newErrMissingResponseField(fieldID)
+	}
+
+	x.err = x.res.obj.ReadFromV2(*idV2)
+	if x.err != nil {
+		x.err = newErrInvalidResponseField(fieldID, x.err)
+	}
+
+	return &x.res, nil
 }
 
 // ObjectPutInit initiates writing an object through a remote server using NeoFS API protocol.
@@ -211,57 +246,25 @@ func (c *Client) ObjectPutInit(ctx context.Context, prm PrmObjectPutInit) (*Obje
 		panic(panicMsgMissingContext)
 	}
 
-	// open stream
-	var (
-		res ResObjectPut
-		w   ObjectWriter
+	var w ObjectWriter
 
-		resp v2object.PutResponse
-	)
-
-	ctx, w.cancelCtxStream = context.WithCancel(ctx)
-
-	w.partInit.SetCopiesNumber(prm.copyNum)
-
-	stream, err := rpcapi.PutObject(&c.c, &resp, client.WithContext(ctx))
+	ctx, cancel := context.WithCancel(ctx)
+	stream, err := rpcapi.PutObject(&c.c, &w.respV2, client.WithContext(ctx))
 	if err != nil {
+		cancel()
 		return nil, fmt.Errorf("open stream: %w", err)
 	}
 
-	// form request body
-	var body v2object.PutRequestBody
-
-	// form request
-	var req v2object.PutRequest
-
-	req.SetBody(&body)
-
-	req.SetMetaHeader(&w.metaHdr)
-	body.SetObjectPart(&w.partInit)
-
-	// init call context
-	c.initCallContext(&w.ctxCall)
-	w.ctxCall.req = &req
-	w.ctxCall.statusRes = &res
-	w.ctxCall.resp = &resp
-	w.ctxCall.wReq = func() error {
-		return stream.Write(&req)
+	w.key = &c.prm.key
+	if prm.key != nil {
+		w.key = prm.key
 	}
-	w.ctxCall.closer = stream.Close
-	w.ctxCall.result = func(r responseV2) {
-		const fieldID = "ID"
-
-		idV2 := r.(*v2object.PutResponse).GetBody().GetObjectID()
-		if idV2 == nil {
-			w.ctxCall.err = newErrMissingResponseField(fieldID)
-			return
-		}
-
-		w.ctxCall.err = res.obj.ReadFromV2(*idV2)
-		if w.ctxCall.err != nil {
-			w.ctxCall.err = newErrInvalidResponseField(fieldID, w.ctxCall.err)
-		}
-	}
+	w.cancelCtxStream = cancel
+	w.client = c
+	w.stream = stream
+	w.partInit.SetCopiesNumber(prm.copyNum)
+	w.req.SetBody(new(v2object.PutRequestBody))
+	c.prepareRequest(&w.req, &prm.meta)
 
 	return &w, nil
 }

--- a/client/object_put.go
+++ b/client/object_put.go
@@ -102,10 +102,6 @@ func (x *PrmObjectPutInit) MarkLocal() {
 //
 // Slice must not be mutated until the operation completes.
 func (x *PrmObjectPutInit) WithXHeaders(hs ...string) {
-	if len(hs)%2 != 0 {
-		panic("slice of X-Headers with odd length")
-	}
-
 	writeXHeadersToMeta(hs, &x.meta)
 }
 

--- a/client/object_put.go
+++ b/client/object_put.go
@@ -97,7 +97,7 @@ func (x *ObjectWriter) WithXHeaders(hs ...string) {
 		panic("slice of X-Headers with odd length")
 	}
 
-	prmCommonMeta{xHeaders: hs}.writeToMetaHeader(&x.metaHdr)
+	writeXHeadersToMeta(hs, &x.metaHdr)
 }
 
 // WriteHeader writes header of the object. Result means success.

--- a/client/object_search.go
+++ b/client/object_search.go
@@ -275,7 +275,7 @@ func (c *Client) ObjectSearchInit(ctx context.Context, prm PrmObjectSearch) (*Ob
 		meta.SetSessionToken(&tokv2)
 	}
 
-	prm.prmCommonMeta.writeToMetaHeader(&meta)
+	writeXHeadersToMeta(prm.prmCommonMeta.xHeaders, &meta)
 
 	// form request
 	var req v2object.SearchRequest

--- a/client/object_search.go
+++ b/client/object_search.go
@@ -67,10 +67,6 @@ func (x *PrmObjectSearch) WithBearerToken(t bearer.Token) {
 //
 // Slice must not be mutated until the operation completes.
 func (x *PrmObjectSearch) WithXHeaders(hs ...string) {
-	if len(hs)%2 != 0 {
-		panic("slice of X-Headers with odd length")
-	}
-
 	writeXHeadersToMeta(hs, &x.meta)
 }
 

--- a/client/session.go
+++ b/client/session.go
@@ -110,11 +110,9 @@ func (c *Client) SessionCreate(ctx context.Context, prm PrmSessionCreate) (*ResS
 		res ResSessionCreate
 	)
 
+	c.initCallContext(&cc)
 	if prm.keySet {
-		c.initCallContextWithoutKey(&cc)
 		cc.key = prm.key
-	} else {
-		c.initCallContext(&cc)
 	}
 
 	cc.meta = prm.prmCommonMeta

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -597,15 +597,15 @@ func (c *clientWrapper) objectGet(ctx context.Context, prm PrmObjectGet) (ResGet
 		cliPrm.WithBearerToken(*prm.btoken)
 	}
 
+	if prm.key != nil {
+		cliPrm.UseKey(*prm.key)
+	}
+
 	var res ResGetObject
 
 	rObj, err := c.client.ObjectGetInit(ctx, cliPrm)
 	if err = c.handleError(nil, err); err != nil {
 		return ResGetObject{}, fmt.Errorf("init object reading on client: %w", err)
-	}
-
-	if prm.key != nil {
-		rObj.UseKey(*prm.key)
 	}
 
 	start := time.Now()

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -684,14 +684,15 @@ func (c *clientWrapper) objectRange(ctx context.Context, prm PrmObjectRange) (Re
 		cliPrm.WithBearerToken(*prm.btoken)
 	}
 
+	if prm.key != nil {
+		cliPrm.UseKey(*prm.key)
+	}
+
 	start := time.Now()
 	res, err := c.client.ObjectRangeInit(ctx, cliPrm)
 	c.incRequests(time.Since(start), methodObjectRange)
 	if err = c.handleError(nil, err); err != nil {
 		return ResObjectRange{}, fmt.Errorf("init payload range reading on client: %w", err)
-	}
-	if prm.key != nil {
-		res.UseKey(*prm.key)
 	}
 
 	return ResObjectRange{

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -717,12 +717,13 @@ func (c *clientWrapper) objectSearch(ctx context.Context, prm PrmObjectSearch) (
 		cliPrm.WithBearerToken(*prm.btoken)
 	}
 
+	if prm.key != nil {
+		cliPrm.UseKey(*prm.key)
+	}
+
 	res, err := c.client.ObjectSearchInit(ctx, cliPrm)
 	if err = c.handleError(nil, err); err != nil {
 		return ResObjectSearch{}, fmt.Errorf("init object searching on client: %w", err)
-	}
-	if prm.key != nil {
-		res.UseKey(*prm.key)
 	}
 
 	return ResObjectSearch{r: res}, nil

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -476,23 +476,21 @@ func (c *clientWrapper) networkInfo(ctx context.Context, _ prmNetworkInfo) (netm
 func (c *clientWrapper) objectPut(ctx context.Context, prm PrmObjectPut) (oid.ID, error) {
 	var cliPrm sdkClient.PrmObjectPutInit
 	cliPrm.SetCopiesNumber(prm.copiesNumber)
+	if prm.stoken != nil {
+		cliPrm.WithinSession(*prm.stoken)
+	}
+	if prm.key != nil {
+		cliPrm.UseKey(*prm.key)
+	}
+	if prm.btoken != nil {
+		cliPrm.WithBearerToken(*prm.btoken)
+	}
 
 	start := time.Now()
 	wObj, err := c.client.ObjectPutInit(ctx, cliPrm)
 	c.incRequests(time.Since(start), methodObjectPut)
 	if err = c.handleError(nil, err); err != nil {
 		return oid.ID{}, fmt.Errorf("init writing on API client: %w", err)
-	}
-
-	if prm.stoken != nil {
-		wObj.WithinSession(*prm.stoken)
-	}
-	if prm.key != nil {
-		wObj.UseKey(*prm.key)
-	}
-
-	if prm.btoken != nil {
-		wObj.WithBearerToken(*prm.btoken)
 	}
 
 	if wObj.WriteHeader(prm.hdr) {


### PR DESCRIPTION
It is nice to have all control-flow in a single file (ideally, on a single screen). In this PR we get rid of using multiple callbacks in object* methods. The result uses less code and is simpler to follow IMO.