### PR TITLE
session: Support group object sessions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/mr-tron/base58 v1.2.0
 	github.com/nspcc-dev/hrw v1.0.9
 	github.com/nspcc-dev/neo-go v0.99.2
-	github.com/nspcc-dev/neofs-api-go/v2 v2.13.2-0.20220919124434-cf868188ef9c
+	github.com/nspcc-dev/neofs-api-go/v2 v2.13.2-0.20221004142957-5fc2644c680d
 	github.com/nspcc-dev/neofs-contract v0.15.3
 	github.com/nspcc-dev/tzhash v1.6.1
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -263,8 +263,8 @@ github.com/nspcc-dev/neo-go/pkg/interop v0.0.0-20220809123759-3094d3e0c14b h1:J7
 github.com/nspcc-dev/neo-go/pkg/interop v0.0.0-20220809123759-3094d3e0c14b/go.mod h1:23bBw0v6pBYcrWs8CBEEDIEDJNbcFoIh8pGGcf2Vv8s=
 github.com/nspcc-dev/neofs-api-go/v2 v2.11.0-pre.0.20211201134523-3604d96f3fe1/go.mod h1:oS8dycEh8PPf2Jjp6+8dlwWyEv2Dy77h/XhhcdxYEFs=
 github.com/nspcc-dev/neofs-api-go/v2 v2.11.1/go.mod h1:oS8dycEh8PPf2Jjp6+8dlwWyEv2Dy77h/XhhcdxYEFs=
-github.com/nspcc-dev/neofs-api-go/v2 v2.13.2-0.20220919124434-cf868188ef9c h1:YZwtBY9uypaShbe/NLhosDanIfxt8VhQlSLYUeFIWv8=
-github.com/nspcc-dev/neofs-api-go/v2 v2.13.2-0.20220919124434-cf868188ef9c/go.mod h1:DRIr0Ic1s+6QgdqmNFNLIqMqd7lNMJfYwkczlm1hDtM=
+github.com/nspcc-dev/neofs-api-go/v2 v2.13.2-0.20221004142957-5fc2644c680d h1:Oc15A8gDoP/TC5kdJi6TW9AnOp5dYiecZ0tJDRUV7vg=
+github.com/nspcc-dev/neofs-api-go/v2 v2.13.2-0.20221004142957-5fc2644c680d/go.mod h1:DRIr0Ic1s+6QgdqmNFNLIqMqd7lNMJfYwkczlm1hDtM=
 github.com/nspcc-dev/neofs-contract v0.15.3 h1:7+NwyTtxFAnIevz0hR/XxQf6R2Ej2scjVR2bnnJnhBM=
 github.com/nspcc-dev/neofs-contract v0.15.3/go.mod h1:BXVZUZUJxrmmDETglXHI8+5DSgn84B9y5DoSWqEjYCs=
 github.com/nspcc-dev/neofs-crypto v0.2.0/go.mod h1:F/96fUzPM3wR+UGsPi3faVNmFlA9KAEAUQR7dMxZmNA=

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -1737,7 +1737,7 @@ func (p *Pool) openDefaultSession(ctx *callContext) error {
 	tok.BindContainer(ctx.sessionCnr)
 
 	if ctx.sessionObjSet {
-		tok.LimitByObject(ctx.sessionObj)
+		tok.LimitByObjects(ctx.sessionObj)
 	}
 
 	// sign the token

--- a/session/test/session.go
+++ b/session/test/session.go
@@ -71,11 +71,9 @@ func Object() *session.Object {
 		panic(err)
 	}
 
-	addr := oidtest.Address()
-
 	tok.ForVerb(session.VerbObjectPut)
-	tok.BindContainer(addr.Container())
-	tok.LimitByObject(addr.Object())
+	tok.BindContainer(cidtest.ID())
+	tok.LimitByObjects(oidtest.ID(), oidtest.ID())
 	tok.SetID(uuid.New())
 	tok.SetAuthKey((*neofsecdsa.PublicKey)(&priv.PublicKey))
 	tok.SetExp(11)


### PR DESCRIPTION
Rename `LimitByObject` method of the `session.Object` type to `LimitByObjects` and make it to accept variadic parameter.

Signed-off-by: Leonard Lyubich <leonard@nspcc.ru>

* based on and blocked by https://github.com/nspcc-dev/neofs-api-go/pull/416