### PR TITLE
netmap: Support `NetmapService.NetmapSnapshot` RPC

### DIFF
--- a/client/api.go
+++ b/client/api.go
@@ -1,0 +1,35 @@
+package client
+
+import (
+	"context"
+	"fmt"
+
+	v2netmap "github.com/nspcc-dev/neofs-api-go/v2/netmap"
+	rpcapi "github.com/nspcc-dev/neofs-api-go/v2/rpc"
+	"github.com/nspcc-dev/neofs-api-go/v2/rpc/client"
+)
+
+// interface of NeoFS API server. Exists for test purposes only.
+type neoFSAPIServer interface {
+	netMapSnapshot(context.Context, v2netmap.SnapshotRequest) (*v2netmap.SnapshotResponse, error)
+}
+
+// wrapper over real client connection which communicates over NeoFS API protocol.
+// Provides neoFSAPIServer for Client instances used in real applications.
+type coreServer client.Client
+
+// unifies errors of all RPC.
+func rpcErr(e error) error {
+	return fmt.Errorf("rpc failure: %w", e)
+}
+
+// executes NetmapService.NetmapSnapshot RPC declared in NeoFS API protocol
+// using underlying client.Client.
+func (x *coreServer) netMapSnapshot(ctx context.Context, req v2netmap.SnapshotRequest) (*v2netmap.SnapshotResponse, error) {
+	resp, err := rpcapi.NetMapSnapshot((*client.Client)(x), &req, client.WithContext(ctx))
+	if err != nil {
+		return nil, rpcErr(err)
+	}
+
+	return resp, nil
+}

--- a/client/client.go
+++ b/client/client.go
@@ -45,6 +45,8 @@ type Client struct {
 	prm PrmInit
 
 	c client.Client
+
+	server neoFSAPIServer
 }
 
 // Init brings the Client instance to its initial state.
@@ -95,10 +97,20 @@ func (c *Client) Dial(prm PrmDial) error {
 		client.WithRWTimeout(prm.streamTimeout),
 	)...)
 
+	c.setNeoFSAPIServer((*coreServer)(&c.c))
+
 	// TODO: (neofs-api-go#382) perform generic dial stage of the client.Client
 	_, _ = rpc.Balance(&c.c, new(v2accounting.BalanceRequest))
 
 	return nil
+}
+
+// sets underlying provider of neoFSAPIServer. The method is used for testing as an approach
+// to skip Dial stage and override NeoFS API server. MUST NOT be used outside test code.
+// In real applications wrapper over github.com/nspcc-dev/neofs-api-go/v2/rpc/client
+// is statically used.
+func (c *Client) setNeoFSAPIServer(server neoFSAPIServer) {
+	c.server = server
 }
 
 // Close closes underlying connection to the NeoFS server. Implements io.Closer.

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,0 +1,39 @@
+package client
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"testing"
+
+	apistatus "github.com/nspcc-dev/neofs-sdk-go/client/status"
+	"github.com/stretchr/testify/require"
+)
+
+/*
+File contains common functionality used for client package testing.
+*/
+
+var key, _ = ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+
+var statusErr apistatus.ServerInternal
+
+func init() {
+	statusErr.SetMessage("test status error")
+}
+
+func assertStatusErr(tb testing.TB, res interface{ Status() apistatus.Status }) {
+	require.IsType(tb, &statusErr, res.Status())
+	require.Equal(tb, statusErr.Message(), res.Status().(*apistatus.ServerInternal).Message())
+}
+
+func newClient(server neoFSAPIServer) *Client {
+	var prm PrmInit
+	prm.SetDefaultPrivateKey(*key)
+
+	var c Client
+	c.Init(prm)
+	c.setNeoFSAPIServer(server)
+
+	return &c
+}

--- a/client/netmap.go
+++ b/client/netmap.go
@@ -253,9 +253,9 @@ func (c *Client) NetMapSnapshot(ctx context.Context, _ PrmNetMapSnapshot) (*ResN
 		return nil, fmt.Errorf("sign request: %w", err)
 	}
 
-	resp, err := rpcapi.NetMapSnapshot(&c.c, &req, client.WithContext(ctx))
+	resp, err := c.server.netMapSnapshot(ctx, req)
 	if err != nil {
-		return nil, fmt.Errorf("rpc failure: %w", err)
+		return nil, err
 	}
 
 	var res ResNetMapSnapshot

--- a/client/netmap_test.go
+++ b/client/netmap_test.go
@@ -1,0 +1,137 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	v2netmap "github.com/nspcc-dev/neofs-api-go/v2/netmap"
+	"github.com/nspcc-dev/neofs-api-go/v2/session"
+	"github.com/nspcc-dev/neofs-api-go/v2/signature"
+	apistatus "github.com/nspcc-dev/neofs-sdk-go/client/status"
+	"github.com/nspcc-dev/neofs-sdk-go/netmap"
+	"github.com/stretchr/testify/require"
+)
+
+type serverNetMap struct {
+	errTransport error
+
+	signResponse bool
+
+	statusOK bool
+
+	setNetMap bool
+	netMap    v2netmap.NetMap
+}
+
+func (x *serverNetMap) netMapSnapshot(ctx context.Context, req v2netmap.SnapshotRequest) (*v2netmap.SnapshotResponse, error) {
+	err := signature.VerifyServiceMessage(&req)
+	if err != nil {
+		return nil, err
+	}
+
+	if x.errTransport != nil {
+		return nil, x.errTransport
+	}
+
+	var body v2netmap.SnapshotResponseBody
+
+	if x.setNetMap {
+		body.SetNetMap(&x.netMap)
+	}
+
+	var meta session.ResponseMetaHeader
+
+	if !x.statusOK {
+		meta.SetStatus(statusErr.ToStatusV2())
+	}
+
+	var resp v2netmap.SnapshotResponse
+	resp.SetBody(&body)
+	resp.SetMetaHeader(&meta)
+
+	if x.signResponse {
+		err = signature.SignServiceMessage(key, &resp)
+		if err != nil {
+			panic(fmt.Sprintf("sign response: %v", err))
+		}
+	}
+
+	return &resp, nil
+}
+
+func TestClient_NetMapSnapshot(t *testing.T) {
+	var err error
+	var prm PrmNetMapSnapshot
+	var res *ResNetMapSnapshot
+	var srv serverNetMap
+	c := newClient(&srv)
+	ctx := context.Background()
+
+	// missing context
+	require.PanicsWithValue(t, panicMsgMissingContext, func() {
+		//nolint:staticcheck
+		_, _ = c.NetMapSnapshot(nil, prm)
+	})
+
+	// request signature
+	srv.errTransport = errors.New("any error")
+
+	_, err = c.NetMapSnapshot(ctx, prm)
+	require.ErrorIs(t, err, srv.errTransport)
+
+	srv.errTransport = nil
+
+	// unsigned response
+	_, err = c.NetMapSnapshot(ctx, prm)
+	require.Error(t, err)
+
+	srv.signResponse = true
+
+	// status failure
+	res, err = c.NetMapSnapshot(ctx, prm)
+	require.NoError(t, err)
+	assertStatusErr(t, res)
+
+	srv.statusOK = true
+
+	// missing netmap field
+	_, err = c.NetMapSnapshot(ctx, prm)
+	require.Error(t, err)
+
+	srv.setNetMap = true
+
+	// invalid network map
+	var netMap netmap.NetMap
+
+	var node netmap.NodeInfo
+	// TODO: #260 use instance corrupter
+
+	var nodeV2 v2netmap.NodeInfo
+
+	node.WriteToV2(&nodeV2)
+	require.Error(t, new(netmap.NodeInfo).ReadFromV2(nodeV2))
+
+	netMap.SetNodes([]netmap.NodeInfo{node})
+	netMap.WriteToV2(&srv.netMap)
+
+	_, err = c.NetMapSnapshot(ctx, prm)
+	require.Error(t, err)
+
+	// correct network map
+	// TODO: #260 use instance normalizer
+	node.SetPublicKey([]byte{1, 2, 3})
+	node.SetNetworkEndpoints("1", "2", "3")
+
+	node.WriteToV2(&nodeV2)
+	require.NoError(t, new(netmap.NodeInfo).ReadFromV2(nodeV2))
+
+	netMap.SetNodes([]netmap.NodeInfo{node})
+	netMap.WriteToV2(&srv.netMap)
+
+	res, err = c.NetMapSnapshot(ctx, prm)
+	require.NoError(t, err)
+	require.True(t, apistatus.IsSuccessful(res.Status()))
+	require.Equal(t, netMap, res.NetMap())
+}

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/mr-tron/base58 v1.2.0
 	github.com/nspcc-dev/hrw v1.0.9
 	github.com/nspcc-dev/neo-go v0.99.2
-	github.com/nspcc-dev/neofs-api-go/v2 v2.13.2-0.20220916145053-f3e1f8ae7ae3
+	github.com/nspcc-dev/neofs-api-go/v2 v2.13.2-0.20220919124434-cf868188ef9c
 	github.com/nspcc-dev/neofs-contract v0.15.3
 	github.com/nspcc-dev/tzhash v1.6.1
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -263,8 +263,8 @@ github.com/nspcc-dev/neo-go/pkg/interop v0.0.0-20220809123759-3094d3e0c14b h1:J7
 github.com/nspcc-dev/neo-go/pkg/interop v0.0.0-20220809123759-3094d3e0c14b/go.mod h1:23bBw0v6pBYcrWs8CBEEDIEDJNbcFoIh8pGGcf2Vv8s=
 github.com/nspcc-dev/neofs-api-go/v2 v2.11.0-pre.0.20211201134523-3604d96f3fe1/go.mod h1:oS8dycEh8PPf2Jjp6+8dlwWyEv2Dy77h/XhhcdxYEFs=
 github.com/nspcc-dev/neofs-api-go/v2 v2.11.1/go.mod h1:oS8dycEh8PPf2Jjp6+8dlwWyEv2Dy77h/XhhcdxYEFs=
-github.com/nspcc-dev/neofs-api-go/v2 v2.13.2-0.20220916145053-f3e1f8ae7ae3 h1:ZPulLHstChUJBKzRcfRSAwZWAZ+jMpPRtSE4Q4EERqM=
-github.com/nspcc-dev/neofs-api-go/v2 v2.13.2-0.20220916145053-f3e1f8ae7ae3/go.mod h1:DRIr0Ic1s+6QgdqmNFNLIqMqd7lNMJfYwkczlm1hDtM=
+github.com/nspcc-dev/neofs-api-go/v2 v2.13.2-0.20220919124434-cf868188ef9c h1:YZwtBY9uypaShbe/NLhosDanIfxt8VhQlSLYUeFIWv8=
+github.com/nspcc-dev/neofs-api-go/v2 v2.13.2-0.20220919124434-cf868188ef9c/go.mod h1:DRIr0Ic1s+6QgdqmNFNLIqMqd7lNMJfYwkczlm1hDtM=
 github.com/nspcc-dev/neofs-contract v0.15.3 h1:7+NwyTtxFAnIevz0hR/XxQf6R2Ej2scjVR2bnnJnhBM=
 github.com/nspcc-dev/neofs-contract v0.15.3/go.mod h1:BXVZUZUJxrmmDETglXHI8+5DSgn84B9y5DoSWqEjYCs=
 github.com/nspcc-dev/neofs-crypto v0.2.0/go.mod h1:F/96fUzPM3wR+UGsPi3faVNmFlA9KAEAUQR7dMxZmNA=

--- a/netmap/netmap_test.go
+++ b/netmap/netmap_test.go
@@ -1,0 +1,47 @@
+package netmap_test
+
+import (
+	"testing"
+
+	v2netmap "github.com/nspcc-dev/neofs-api-go/v2/netmap"
+	"github.com/nspcc-dev/neofs-sdk-go/netmap"
+	netmaptest "github.com/nspcc-dev/neofs-sdk-go/netmap/test"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNetMapNodes(t *testing.T) {
+	var nm netmap.NetMap
+
+	require.Empty(t, nm.Nodes())
+
+	nodes := []netmap.NodeInfo{netmaptest.NodeInfo(), netmaptest.NodeInfo()}
+
+	nm.SetNodes(nodes)
+	require.ElementsMatch(t, nodes, nm.Nodes())
+
+	nodesV2 := make([]v2netmap.NodeInfo, len(nodes))
+	for i := range nodes {
+		nodes[i].WriteToV2(&nodesV2[i])
+	}
+
+	var m v2netmap.NetMap
+	nm.WriteToV2(&m)
+
+	require.ElementsMatch(t, nodesV2, m.Nodes())
+}
+
+func TestNetMap_SetEpoch(t *testing.T) {
+	var nm netmap.NetMap
+
+	require.Zero(t, nm.Epoch())
+
+	const e = 158
+
+	nm.SetEpoch(e)
+	require.EqualValues(t, e, nm.Epoch())
+
+	var m v2netmap.NetMap
+	nm.WriteToV2(&m)
+
+	require.EqualValues(t, e, m.Epoch())
+}

--- a/netmap/test/generate.go
+++ b/netmap/test/generate.go
@@ -1,6 +1,8 @@
 package netmaptest
 
 import (
+	"math/rand"
+
 	"github.com/nspcc-dev/neofs-sdk-go/netmap"
 	subnetidtest "github.com/nspcc-dev/neofs-sdk-go/subnet/id/test"
 )
@@ -65,6 +67,17 @@ func NetworkInfo() (x netmap.NetworkInfo) {
 	x.SetIRCandidateFee(7)
 	x.SetMaxObjectSize(8)
 	x.SetWithdrawalFee(9)
+
+	return
+}
+
+// NodeInfo returns random netmap.NodeInfo.
+func NodeInfo() (x netmap.NodeInfo) {
+	key := make([]byte, 33)
+	rand.Read(key)
+
+	x.SetPublicKey(key)
+	x.SetNetworkEndpoints("1", "2", "3")
 
 	return
 }


### PR DESCRIPTION
Extend functionality of `NetMap` type. Add `NetMapSnapshot` operation to `client` package.

* based on and blocked by https://github.com/nspcc-dev/neofs-api-go/pull/418