### PR TITLE
Decode `MAINTENANCE` error from status messages

### DIFF
--- a/client/status/common.go
+++ b/client/status/common.go
@@ -183,9 +183,14 @@ type NodeUnderMaintenance struct {
 
 // Error implements the error interface.
 func (x NodeUnderMaintenance) Error() string {
+	msg := x.Message()
+	if msg == "" {
+		msg = "node is under maintenance"
+	}
+
 	return errMessageStatusV2(
 		globalizeCodeV2(status.NodeUnderMaintenance, status.GlobalizeCommonFail),
-		x.v2.Message(),
+		msg,
 	)
 }
 

--- a/client/status/v2.go
+++ b/client/status/v2.go
@@ -58,6 +58,8 @@ func FromStatusV2(st *status.Status) Status {
 			decoder = new(WrongMagicNumber)
 		case status.SignatureVerificationFail:
 			decoder = new(SignatureVerification)
+		case status.NodeUnderMaintenance:
+			decoder = new(NodeUnderMaintenance)
 		}
 	case object.LocalizeFailStatus(&code):
 		switch code {

--- a/client/status/v2_test.go
+++ b/client/status/v2_test.go
@@ -125,6 +125,12 @@ func TestToStatusV2(t *testing.T) {
 			}),
 			codeV2: 4097,
 		},
+		{
+			status: (statusConstructor)(func() apistatus.Status {
+				return new(apistatus.NodeUnderMaintenance)
+			}),
+			codeV2: 1027,
+		},
 	} {
 		var st apistatus.Status
 
@@ -271,6 +277,12 @@ func TestFromStatusV2(t *testing.T) {
 				return new(apistatus.SessionTokenExpired)
 			}),
 			codeV2: 4097,
+		},
+		{
+			status: (statusConstructor)(func() apistatus.Status {
+				return new(apistatus.NodeUnderMaintenance)
+			}),
+			codeV2: 1027,
 		},
 	} {
 		var st apistatus.Status


### PR DESCRIPTION
* relates #315

We previously forgot to do this in https://github.com/nspcc-dev/neofs-sdk-go/pull/335. I've left an issue to prevent this in future https://github.com/nspcc-dev/neofs-sdk-go/issues/340.