### PR TITLE
Fix/Clarify expiration epoch

### DIFF
--- a/bearer/bearer.go
+++ b/bearer/bearer.go
@@ -136,9 +136,10 @@ func (b Token) WriteToV2(m *acl.BearerToken) {
 }
 
 // SetExp sets "exp" (expiration time) claim which identifies the
-// expiration time (in NeoFS epochs) on or after which the Token MUST NOT be
-// accepted for processing. The processing of the "exp" claim requires that the
-// current epoch MUST be before the expiration epoch listed in the "exp" claim.
+// expiration time (in NeoFS epochs) after which the Token MUST NOT be
+// accepted for processing. The processing of the "exp" claim requires
+// that the current epoch MUST be before or equal to the expiration epoch
+// listed in the "exp" claim.
 //
 // Naming is inspired by https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.4.
 //
@@ -179,7 +180,7 @@ func (b *Token) SetIat(iat uint64) {
 //
 // See also SetExp, SetNbf, SetIat.
 func (b Token) InvalidAt(epoch uint64) bool {
-	return !b.lifetimeSet || b.nbf > epoch || b.iat > epoch || b.exp <= epoch
+	return !b.lifetimeSet || b.nbf > epoch || b.iat > epoch || b.exp < epoch
 }
 
 // SetEACLTable sets eacl.Table that replaces the one from the issuer's

--- a/bearer/bearer_test.go
+++ b/bearer/bearer_test.go
@@ -220,7 +220,7 @@ func TestToken_InvalidAt(t *testing.T) {
 	require.True(t, val.InvalidAt(1))
 	require.False(t, val.InvalidAt(2))
 	require.False(t, val.InvalidAt(3))
-	require.True(t, val.InvalidAt(4))
+	require.False(t, val.InvalidAt(4))
 	require.True(t, val.InvalidAt(5))
 }
 

--- a/object/tombstone.go
+++ b/object/tombstone.go
@@ -33,12 +33,18 @@ func (t *Tombstone) ToV2() *tombstone.Tombstone {
 	return (*tombstone.Tombstone)(t)
 }
 
-// ExpirationEpoch return number of tombstone expiration epoch.
+// ExpirationEpoch returns the last NeoFS epoch
+// number of the tombstone lifetime.
+//
+// See also SetExpirationEpoch.
 func (t *Tombstone) ExpirationEpoch() uint64 {
 	return (*tombstone.Tombstone)(t).GetExpirationEpoch()
 }
 
-// SetExpirationEpoch sets number of tombstone expiration epoch.
+// SetExpirationEpoch sets the last NeoFS epoch
+// number of the tombstone lifetime.
+//
+// See also ExpirationEpoch.
 func (t *Tombstone) SetExpirationEpoch(v uint64) {
 	(*tombstone.Tombstone)(t).SetExpirationEpoch(v)
 }

--- a/session/common.go
+++ b/session/common.go
@@ -219,10 +219,11 @@ func (x *commonData) unmarshalJSON(data []byte, r contextReader) error {
 	return x.readFromV2(m, false, r)
 }
 
-// SetExp sets "exp" (expiration time) claim which identifies the expiration time
-// (in NeoFS epochs) on or after which the session MUST NOT be accepted for
-// processing.  The processing of the "exp" claim requires that the current
-// epoch MUST be before the expiration epoch listed in the "exp" claim.
+// SetExp sets "exp" (expiration time) claim which identifies the expiration
+// time (in NeoFS epochs) after which the session MUST NOT be accepted for
+// processing. The processing of the "exp" claim requires that the current
+// epoch MUST be before or equal to the expiration epoch listed in the "exp"
+// claim.
 //
 // Naming is inspired by https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.4.
 //
@@ -258,7 +259,7 @@ func (x *commonData) SetIat(iat uint64) {
 }
 
 func (x commonData) expiredAt(epoch uint64) bool {
-	return !x.lifetimeSet || x.exp <= epoch
+	return !x.lifetimeSet || x.exp < epoch
 }
 
 // InvalidAt asserts "exp", "nbf" and "iat" claims.

--- a/session/container_test.go
+++ b/session/container_test.go
@@ -153,7 +153,8 @@ func TestContainerProtocolV2(t *testing.T) {
 			assert: func(val session.Container) {
 				require.True(t, val.InvalidAt(1))
 				require.False(t, val.InvalidAt(2))
-				require.True(t, val.InvalidAt(3))
+				require.False(t, val.InvalidAt(3))
+				require.True(t, val.InvalidAt(4))
 			},
 			breakSign: func(m *v2session.Token) {
 				lt := m.GetBody().GetLifetime()
@@ -410,7 +411,8 @@ func TestContainer_InvalidAt(t *testing.T) {
 	require.True(t, x.InvalidAt(nbf-1))
 	require.True(t, x.InvalidAt(iat-1))
 	require.False(t, x.InvalidAt(iat))
-	require.True(t, x.InvalidAt(exp))
+	require.False(t, x.InvalidAt(exp))
+	require.True(t, x.InvalidAt(exp+1))
 }
 
 func TestContainer_ID(t *testing.T) {

--- a/session/object_test.go
+++ b/session/object_test.go
@@ -175,7 +175,8 @@ func TestObjectProtocolV2(t *testing.T) {
 			assert: func(val session.Object) {
 				require.True(t, val.InvalidAt(1))
 				require.False(t, val.InvalidAt(2))
-				require.True(t, val.InvalidAt(3))
+				require.False(t, val.InvalidAt(3))
+				require.True(t, val.InvalidAt(4))
 			},
 			breakSign: func(m *v2session.Token) {
 				lt := m.GetBody().GetLifetime()
@@ -520,7 +521,8 @@ func TestObject_InvalidAt(t *testing.T) {
 	require.True(t, x.InvalidAt(nbf-1))
 	require.True(t, x.InvalidAt(iat-1))
 	require.False(t, x.InvalidAt(iat))
-	require.True(t, x.InvalidAt(exp))
+	require.False(t, x.InvalidAt(exp))
+	require.True(t, x.InvalidAt(exp+1))
 }
 
 func TestObject_ID(t *testing.T) {


### PR DESCRIPTION
The expiration epoch is the _last_ valid epoch for an entity. Also, clarify 
the expiration epoch meaning for tombstones and regular objects.

Signed-off-by: Pavel Karpy <p.karpy@yadro.com>

Closes #370.