### PR TITLE
[#374] pool: Fix handling SplitInfoError

### DIFF
--- a/pool/pool.go
+++ b/pool/pool.go
@@ -984,7 +984,14 @@ func (c *clientWrapper) incRequests(elapsed time.Duration, method MethodIndex) {
 
 func (c *clientStatusMonitor) handleError(st apistatus.Status, err error) error {
 	if err != nil {
-		c.incErrorRate()
+		// non-status logic error that could be returned
+		// from the SDK client; should not be considered
+		// as a connection error
+		var siErr *object.SplitInfoError
+		if !errors.As(err, &siErr) {
+			c.incErrorRate()
+		}
+
 		return err
 	}
 


### PR DESCRIPTION
Similar to https://github.com/nspcc-dev/neofs-node/pull/2196

Problem:
During removing big object pool finds all small parts to form a valid session token. 
This leads to [using `raw` flag](https://github.com/nspcc-dev/neofs-sdk-go/blob/170f31b7c45469565a1dd0990d65484f6f686068/pool/pool.go#L2539) and getting `SplitErrorInfo` in built-in error (not in status). Such errors increase [error counter](https://github.com/nspcc-dev/neofs-sdk-go/blob/170f31b7c45469565a1dd0990d65484f6f686068/pool/pool.go#L987) and after 100 (default value) such errors connection to this node marks as `unhealthy`. 

