### PR TITLE
Strip useless res structs

### DIFF
--- a/client/container.go
+++ b/client/container.go
@@ -429,16 +429,6 @@ type PrmContainerEACL struct {
 	prmCommonMeta
 }
 
-// ResContainerEACL groups resulting values of ContainerEACL operation.
-type ResContainerEACL struct {
-	table eacl.Table
-}
-
-// Table returns eACL table of the requested container.
-func (x ResContainerEACL) Table() eacl.Table {
-	return x.table
-}
-
 // ContainerEACL reads eACL table of the NeoFS container.
 //
 // Any errors (local or remote, including returned status codes) are returned as Go errors,
@@ -448,9 +438,9 @@ func (x ResContainerEACL) Table() eacl.Table {
 //
 // Return errors:
 //   - [ErrMissingSigner]
-func (c *Client) ContainerEACL(ctx context.Context, id cid.ID, prm PrmContainerEACL) (*ResContainerEACL, error) {
+func (c *Client) ContainerEACL(ctx context.Context, id cid.ID, prm PrmContainerEACL) (eacl.Table, error) {
 	if c.prm.signer == nil {
-		return nil, ErrMissingSigner
+		return eacl.Table{}, ErrMissingSigner
 	}
 
 	var cidV2 refs.ContainerID
@@ -469,7 +459,7 @@ func (c *Client) ContainerEACL(ctx context.Context, id cid.ID, prm PrmContainerE
 
 	var (
 		cc  contextCall
-		res ResContainerEACL
+		res eacl.Table
 	)
 
 	c.initCallContext(&cc)
@@ -487,15 +477,15 @@ func (c *Client) ContainerEACL(ctx context.Context, id cid.ID, prm PrmContainerE
 			return
 		}
 
-		res.table = *eacl.NewTableFromV2(eACL)
+		res = *eacl.NewTableFromV2(eACL)
 	}
 
 	// process call
 	if !cc.processCall() {
-		return nil, cc.err
+		return eacl.Table{}, cc.err
 	}
 
-	return &res, nil
+	return res, nil
 }
 
 // PrmContainerSetEACL groups optional parameters of ContainerSetEACL operation.

--- a/client/container.go
+++ b/client/container.go
@@ -656,7 +656,7 @@ func SyncContainerWithNetwork(ctx context.Context, cnr *container.Container, c *
 		return fmt.Errorf("network info call: %w", err)
 	}
 
-	container.ApplyNetworkConfig(cnr, res.Info())
+	container.ApplyNetworkConfig(cnr, res)
 
 	return nil
 }

--- a/client/example_container_put_test.go
+++ b/client/example_container_put_test.go
@@ -81,13 +81,12 @@ func ExampleClient_ContainerPut() {
 	placementPolicy.SetContainerBackupFactor(1)
 	cont.SetPlacementPolicy(placementPolicy)
 
-	putResult, err := c.ContainerPut(ctx, cont, client.PrmContainerPut{})
+	containerID, err = c.ContainerPut(ctx, cont, client.PrmContainerPut{})
 	if err != nil {
 		panic(fmt.Errorf("ContainerPut %w", err))
 	}
 
 	// containerID already exists
-	containerID = putResult.ID()
 	fmt.Println(containerID)
 	// example output: 76wa5UNiT8gk8Q5rdCVCV4pKuZSmYsifh6g84BcL6Hqs
 

--- a/client/example_container_put_test.go
+++ b/client/example_container_put_test.go
@@ -95,12 +95,12 @@ func ExampleClient_ContainerPut() {
 	// for simplifying we just wait
 	<-time.After(2 * time.Second)
 
-	getResp, err := c.ContainerGet(ctx, containerID, client.PrmContainerGet{})
+	contRes, err := c.ContainerGet(ctx, containerID, client.PrmContainerGet{})
 	if err != nil {
 		panic(fmt.Errorf("ContainerGet %w", err))
 	}
 
-	jsonData, err := getResp.Container().MarshalJSON()
+	jsonData, err := contRes.MarshalJSON()
 	if err != nil {
 		panic(fmt.Errorf("MarshalJSON %w", err))
 	}

--- a/client/netmap.go
+++ b/client/netmap.go
@@ -116,16 +116,6 @@ type PrmNetworkInfo struct {
 	prmCommonMeta
 }
 
-// ResNetworkInfo groups resulting values of NetworkInfo operation.
-type ResNetworkInfo struct {
-	info netmap.NetworkInfo
-}
-
-// Info returns structured information about the NeoFS network.
-func (x ResNetworkInfo) Info() netmap.NetworkInfo {
-	return x.info
-}
-
 // NetworkInfo requests information about the NeoFS network of which the remote server is a part.
 //
 // Any client's internal or transport errors are returned as `error`,
@@ -133,9 +123,8 @@ func (x ResNetworkInfo) Info() netmap.NetworkInfo {
 //
 // Context is required and must not be nil. It is used for network communication.
 //
-// Exactly one return value is non-nil. Server status return is returned in ResNetworkInfo.
 // Reflects all internal errors in second return value (transport problems, response processing, etc.).
-func (c *Client) NetworkInfo(ctx context.Context, prm PrmNetworkInfo) (*ResNetworkInfo, error) {
+func (c *Client) NetworkInfo(ctx context.Context, prm PrmNetworkInfo) (netmap.NetworkInfo, error) {
 	// form request
 	var req v2netmap.NetworkInfoRequest
 
@@ -143,7 +132,7 @@ func (c *Client) NetworkInfo(ctx context.Context, prm PrmNetworkInfo) (*ResNetwo
 
 	var (
 		cc  contextCall
-		res ResNetworkInfo
+		res netmap.NetworkInfo
 	)
 
 	c.initCallContext(&cc)
@@ -163,7 +152,7 @@ func (c *Client) NetworkInfo(ctx context.Context, prm PrmNetworkInfo) (*ResNetwo
 			return
 		}
 
-		cc.err = res.info.ReadFromV2(*netInfoV2)
+		cc.err = res.ReadFromV2(*netInfoV2)
 		if cc.err != nil {
 			cc.err = newErrInvalidResponseField(fieldNetInfo, cc.err)
 			return
@@ -172,10 +161,10 @@ func (c *Client) NetworkInfo(ctx context.Context, prm PrmNetworkInfo) (*ResNetwo
 
 	// process call
 	if !cc.processCall() {
-		return nil, cc.err
+		return netmap.NetworkInfo{}, cc.err
 	}
 
-	return &res, nil
+	return res, nil
 }
 
 // PrmNetMapSnapshot groups parameters of NetMapSnapshot operation.

--- a/client/netmap_test.go
+++ b/client/netmap_test.go
@@ -72,7 +72,7 @@ func (x *serverNetMap) netMapSnapshot(_ context.Context, req v2netmap.SnapshotRe
 func TestClient_NetMapSnapshot(t *testing.T) {
 	var err error
 	var prm PrmNetMapSnapshot
-	var res *ResNetMapSnapshot
+	var res netmap.NetMap
 	var srv serverNetMap
 
 	signer := test.RandomSignerRFC6979(t)
@@ -139,7 +139,7 @@ func TestClient_NetMapSnapshot(t *testing.T) {
 
 	res, err = c.NetMapSnapshot(ctx, prm)
 	require.NoError(t, err)
-	require.Equal(t, netMap, res.NetMap())
+	require.Equal(t, netMap, res)
 }
 
 func TestClient_NetMapSnapshot_MissingSigner(t *testing.T) {

--- a/client/object_hash.go
+++ b/client/object_hash.go
@@ -106,16 +106,6 @@ func (x *PrmObjectHash) WithXHeaders(hs ...string) {
 	writeXHeadersToMeta(hs, &x.meta)
 }
 
-// ResObjectHash groups resulting values of ObjectHash operation.
-type ResObjectHash struct {
-	checksums [][]byte
-}
-
-// Checksums returns a list of calculated checksums in range order.
-func (x ResObjectHash) Checksums() [][]byte {
-	return x.checksums
-}
-
 // ObjectHash requests checksum of the range list of the object payload using
 // NeoFS API protocol.
 //
@@ -131,7 +121,7 @@ func (x ResObjectHash) Checksums() [][]byte {
 // Return errors:
 //   - [ErrMissingRanges]
 //   - [ErrMissingSigner]
-func (c *Client) ObjectHash(ctx context.Context, containerID cid.ID, objectID oid.ID, prm PrmObjectHash) (*ResObjectHash, error) {
+func (c *Client) ObjectHash(ctx context.Context, containerID cid.ID, objectID oid.ID, prm PrmObjectHash) ([][]byte, error) {
 	var (
 		addr  v2refs.Address
 		cidV2 v2refs.ContainerID
@@ -174,15 +164,15 @@ func (c *Client) ObjectHash(ctx context.Context, containerID cid.ID, objectID oi
 		return nil, fmt.Errorf("write request: %w", err)
 	}
 
-	var res ResObjectHash
+	var res [][]byte
 	if err = c.processResponse(resp); err != nil {
 		return nil, err
 	}
 
-	res.checksums = resp.GetBody().GetHashList()
-	if len(res.checksums) == 0 {
+	res = resp.GetBody().GetHashList()
+	if len(res) == 0 {
 		return nil, newErrMissingResponseField("hash list")
 	}
 
-	return &res, nil
+	return res, nil
 }

--- a/client/object_put.go
+++ b/client/object_put.go
@@ -342,12 +342,10 @@ func CreateObject(ctx context.Context, cli *Client, signer neofscrypto.Signer, c
 // future. Be ready to refactor your code regarding imports and call mechanics,
 // in essence the operation will not change.
 func NewDataSlicer(ctx context.Context, cli *Client, signer neofscrypto.Signer, cnr cid.ID, owner user.ID) (*slicer.Slicer, error) {
-	resNetInfo, err := cli.NetworkInfo(ctx, PrmNetworkInfo{})
+	netInfo, err := cli.NetworkInfo(ctx, PrmNetworkInfo{})
 	if err != nil {
 		return nil, fmt.Errorf("read current network info: %w", err)
 	}
-
-	netInfo := resNetInfo.Info()
 
 	var opts slicer.Options
 	opts.SetObjectPayloadLimit(netInfo.MaxObjectSize())

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -570,7 +570,7 @@ func (c *clientWrapper) networkInfo(ctx context.Context, _ prmNetworkInfo) (netm
 		return netmap.NetworkInfo{}, fmt.Errorf("network info on client: %w", err)
 	}
 
-	return res.Info(), nil
+	return res, nil
 }
 
 // objectPut writes object to NeoFS.

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -385,7 +385,7 @@ func (c *clientWrapper) balanceGet(ctx context.Context, prm PrmBalanceGet) (acco
 		return accounting.Decimal{}, fmt.Errorf("balance get on client: %w", err)
 	}
 
-	return res.Amount(), nil
+	return res, nil
 }
 
 // containerPut invokes sdkClient.ContainerPut parse response status to error and return result as is.

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -434,7 +434,7 @@ func (c *clientWrapper) containerGet(ctx context.Context, cnrID cid.ID) (contain
 		return container.Container{}, fmt.Errorf("container get on client: %w", err)
 	}
 
-	return res.Container(), nil
+	return res, nil
 }
 
 // containerList invokes sdkClient.ContainerList parse response status to error and return result as is.

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -497,7 +497,7 @@ func (c *clientWrapper) containerEACL(ctx context.Context, id cid.ID) (eacl.Tabl
 		return eacl.Table{}, fmt.Errorf("get eacl on client: %w", err)
 	}
 
-	return res.Table(), nil
+	return res, nil
 }
 
 // containerSetEACL invokes sdkClient.ContainerSetEACL parse response status to error.

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -397,7 +397,7 @@ func (c *clientWrapper) containerPut(ctx context.Context, cont container.Contain
 	}
 
 	start := time.Now()
-	res, err := cl.ContainerPut(ctx, cont, prm.prmClient)
+	idCnr, err := cl.ContainerPut(ctx, cont, prm.prmClient)
 	c.incRequests(time.Since(start), methodContainerPut)
 	c.updateErrorRate(err)
 	if err != nil {
@@ -407,8 +407,6 @@ func (c *clientWrapper) containerPut(ctx context.Context, cont container.Contain
 	if !prm.waitParamsSet {
 		prm.waitParams.setDefaults()
 	}
-
-	idCnr := res.ID()
 
 	err = waitForContainerPresence(ctx, c, idCnr, &prm.waitParams)
 	c.updateErrorRate(err)

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -451,7 +451,7 @@ func (c *clientWrapper) containerList(ctx context.Context, ownerID user.ID) ([]c
 	if err != nil {
 		return nil, fmt.Errorf("container list on client: %w", err)
 	}
-	return res.Containers(), nil
+	return res, nil
 }
 
 // containerDelete invokes sdkClient.ContainerDelete parse response status to error.


### PR DESCRIPTION
We've got a number of `Res*` things with a single member only. They were somewhat useful before #413 (to get request status), but now they provide zero value and just complicate the code using these APIs. Notice also that this makes `client` interface a little close to `pool` interface which is nice wrt. #380.