### PR TITLE
Fix/Broken linking objects

### DIFF
--- a/object/slicer/slicer.go
+++ b/object/slicer/slicer.go
@@ -334,6 +334,7 @@ type PayloadWriter struct {
 	currentWriter limitedWriter
 
 	withSplit bool
+	splitID   *object.SplitID
 
 	writtenChildren []oid.ID
 }
@@ -353,6 +354,8 @@ func (x *PayloadWriter) Write(chunk []byte) (int, error) {
 	}
 
 	if !x.withSplit {
+		x.splitID = object.NewSplitID()
+
 		err = x.writeIntermediateChild(x.rootMeta)
 		if err != nil {
 			return n, fmt.Errorf("write 1st child: %w", err)
@@ -421,6 +424,10 @@ func (x *PayloadWriter) _writeChild(meta dynamicObjectMetadata, last bool, rootI
 		obj.SetType(object.TypeRegular)
 		obj.SetOwnerID(&x.owner)
 		obj.SetSessionToken(x.sessionToken)
+
+		if x.withSplit {
+			obj.SetSplitID(x.splitID)
+		}
 	}
 
 	var obj object.Object

--- a/object/slicer/slicer.go
+++ b/object/slicer/slicer.go
@@ -472,6 +472,7 @@ func (x *PayloadWriter) _writeChild(meta dynamicObjectMetadata, last bool, rootI
 	x.writtenChildren = append(x.writtenChildren, id)
 
 	if x.withSplit && last {
+		meta.reset()
 		obj.ResetPreviousID()
 		obj.SetChildren(x.writtenChildren...)
 


### PR DESCRIPTION
Did not allow updating `neofs-node` cause it was sending broken linking objects that had non-empty payload length and any replication failed (link objects do not have payload).