### PR TITLE
Use container in pools objectDelete

### DIFF
--- a/pool/pool.go
+++ b/pool/pool.go
@@ -1923,6 +1923,7 @@ func (p *Pool) DeleteObject(ctx context.Context, containerID cid.ID, objectID oi
 	var prmCtx prmContext
 	prmCtx.useDefaultSession()
 	prmCtx.useVerb(session.VerbObjectDelete)
+	prmCtx.useContainer(containerID)
 
 	if prm.stoken == nil { // collect phy objects only if we are about to open default session
 		var tokens relations.Tokens


### PR DESCRIPTION
The logic with container set was broken after [this commit ](https://github.com/nspcc-dev/neofs-sdk-go/commit/22ac6f536da1e441e56c1500da9f2631b34951c3#diff-7dc553983ffc8155d2dc76de139b8b581f7d7161d2b640d59e62d5c499c23c12L1995)