### PR TITLE
slicer: Do not write split ID into parent header

### DIFF
--- a/object/slicer/slicer.go
+++ b/object/slicer/slicer.go
@@ -429,14 +429,13 @@ func (x *PayloadWriter) _writeChild(meta dynamicObjectMetadata, last bool, rootI
 		obj.SetType(object.TypeRegular)
 		obj.SetOwnerID(&x.owner)
 		obj.SetSessionToken(x.sessionToken)
-
-		if x.withSplit {
-			obj.SetSplitID(x.splitID)
-		}
 	}
 
 	var obj object.Object
 	fCommon(&obj)
+	if x.withSplit {
+		obj.SetSplitID(x.splitID)
+	}
 	if len(x.writtenChildren) > 0 {
 		obj.SetPreviousID(x.writtenChildren[len(x.writtenChildren)-1])
 	}

--- a/object/slicer/slicer_test.go
+++ b/object/slicer/slicer_test.go
@@ -545,6 +545,12 @@ func TestSlicedObjectsHaveSplitID(t *testing.T) {
 	opts.SetObjectPayloadLimit(maxObjectSize)
 	opts.SetCurrentNeoFSEpoch(10)
 
+	checkParentWithoutSplitInfo := func(hdr object.Object) {
+		for o := hdr.Parent(); o != nil; o = o.Parent() {
+			require.Nil(t, o.ToV2().GetHeader().GetSplit())
+		}
+	}
+
 	t.Run("slice", func(t *testing.T) {
 		writer := &memoryWriter{}
 		sl := slicer.New(signer, containerID, ownerID, writer, opts)
@@ -562,6 +568,7 @@ func TestSlicedObjectsHaveSplitID(t *testing.T) {
 			splitID := h.SplitID()
 			require.NotNil(t, splitID)
 			require.Equal(t, writer.splitID.ToV2(), splitID.ToV2())
+			checkParentWithoutSplitInfo(h)
 		}
 	})
 
@@ -588,6 +595,7 @@ func TestSlicedObjectsHaveSplitID(t *testing.T) {
 			splitID := h.SplitID()
 			require.NotNil(t, splitID)
 			require.Equal(t, writer.splitID.ToV2(), splitID.ToV2())
+			checkParentWithoutSplitInfo(h)
 		}
 	})
 
@@ -607,6 +615,7 @@ func TestSlicedObjectsHaveSplitID(t *testing.T) {
 		for _, h := range writer.headers {
 			splitID := h.SplitID()
 			require.Nil(t, splitID)
+			checkParentWithoutSplitInfo(h)
 		}
 	})
 }


### PR DESCRIPTION
Split ID relates to split-chain only, original root object should not carry this information, otherwise, it will be perceived by the system itself as part of a sliced chain that does not exist.