### PR TITLE
Document mutability of reference types

### DIFF
--- a/audit/result.go
+++ b/audit/result.go
@@ -139,8 +139,10 @@ func (r *Result) ForContainer(cnr cid.ID) {
 // AuditorKey returns public key of the auditing NeoFS Inner Ring node in
 // a NeoFS binary key format.
 //
-// Zero Result has nil key. Return value MUST NOT be mutated: to do this,
-// first make a copy.
+// Zero Result has nil key.
+//
+// The value returned shares memory with the structure itself, so changing it can lead to data corruption.
+// Make a copy if you need to change it.
 //
 // The resulting slice of bytes is a serialized compressed public key. See [elliptic.MarshalCompressed].
 // Use [neofsecdsa.PublicKey.Decode] to decode it into a type-specific structure.

--- a/bearer/bearer.go
+++ b/bearer/bearer.go
@@ -345,6 +345,9 @@ func (b *Token) UnmarshalJSON(data []byte) error {
 // The resulting slice of bytes is a serialized compressed public key. See [elliptic.MarshalCompressed].
 // Use [neofsecdsa.PublicKey.Decode] to decode it into a type-specific structure.
 //
+// The value returned shares memory with the structure itself, so changing it can lead to data corruption.
+// Make a copy if you need to change it.
+//
 // See also [Token.ResolveIssuer].
 func (b Token) SigningKeyBytes() []byte {
 	if b.sigSet {

--- a/checksum/checksum.go
+++ b/checksum/checksum.go
@@ -87,6 +87,9 @@ func (c Checksum) Type() Type {
 //
 // Zero Checksum has nil sum.
 //
+// The value returned shares memory with the structure itself, so changing it can lead to data corruption.
+// Make a copy if you need to change it.
+//
 // See also SetTillichZemor and SetSHA256.
 func (c Checksum) Value() []byte {
 	v2 := (refs.Checksum)(c)

--- a/client/response.go
+++ b/client/response.go
@@ -19,7 +19,8 @@ type responseV2 interface {
 // The resulting slice of bytes is a serialized compressed public key. See [elliptic.MarshalCompressed].
 // Use [neofsecdsa.PublicKey.Decode] to decode it into a type-specific structure.
 //
-// Result must not be mutated.
+// The value returned shares memory with the structure itself, so changing it can lead to data corruption.
+// Make a copy if you need to change it.
 func (x ResponseMetaInfo) ResponderKey() []byte {
 	return x.key
 }

--- a/client/session.go
+++ b/client/session.go
@@ -56,6 +56,9 @@ func (x *ResSessionCreate) setSessionKey(key []byte) {
 //
 // The resulting slice of bytes is a serialized compressed public key. See [elliptic.MarshalCompressed].
 // Use [neofsecdsa.PublicKey.Decode] to decode it into a type-specific structure.
+//
+// The value returned shares memory with the structure itself, so changing it can lead to data corruption.
+// Make a copy if you need to change it.
 func (x ResSessionCreate) PublicKey() []byte {
 	return x.sessionKey
 }

--- a/crypto/signature.go
+++ b/crypto/signature.go
@@ -139,12 +139,18 @@ func (x Signature) PublicKey() PublicKey {
 // PublicKeyBytes MUST NOT be called before [Signature.ReadFromV2] or
 // [Signature.Calculate] methods.
 //
+// The value returned shares memory with the structure itself, so changing it can lead to data corruption.
+// Make a copy if you need to change it.
+//
 // See also [Signature.PublicKey].
 func (x Signature) PublicKeyBytes() []byte {
 	return (*refs.Signature)(&x).GetKey()
 }
 
 // Value returns calculated digital signature.
+//
+// The value returned shares memory with the structure itself, so changing it can lead to data corruption.
+// Make a copy if you need to change it.
 //
 // Value MUST NOT be called before [Signature.ReadFromV2] or
 // [Signature.Calculate] methods.

--- a/crypto/signer.go
+++ b/crypto/signer.go
@@ -132,6 +132,9 @@ func (s *StaticSigner) Scheme() Scheme {
 // Sign returns precalculated serialized signature that was provided upon
 // [StaticSigner] creation. Never returns an error.
 // Implements [Signer].
+//
+// The value returned shares memory with the structure itself, so changing it can lead to data corruption.
+// Make a copy if you need to change it.
 func (s *StaticSigner) Sign(_ []byte) ([]byte, error) {
 	return s.sig, nil
 }

--- a/eacl/record.go
+++ b/eacl/record.go
@@ -24,6 +24,9 @@ type Record struct {
 }
 
 // Targets returns list of target subjects to apply ACL rule to.
+//
+// The value returned shares memory with the structure itself, so changing it can lead to data corruption.
+// Make a copy if you need to change it.
 func (r Record) Targets() []Target {
 	return r.targets
 }
@@ -34,6 +37,9 @@ func (r *Record) SetTargets(targets ...Target) {
 }
 
 // Filters returns list of filters to match and see if rule is applicable.
+//
+// The value returned shares memory with the structure itself, so changing it can lead to data corruption.
+// Make a copy if you need to change it.
 func (r Record) Filters() []Filter {
 	return r.filters
 }

--- a/eacl/table.go
+++ b/eacl/table.go
@@ -45,6 +45,9 @@ func (t *Table) SetVersion(version version.Version) {
 }
 
 // Records returns list of extended ACL rules.
+//
+// The value returned shares memory with the structure itself, so changing it can lead to data corruption.
+// Make a copy if you need to change it.
 func (t Table) Records() []Record {
 	return t.records
 }

--- a/eacl/target.go
+++ b/eacl/target.go
@@ -32,6 +32,9 @@ func ecdsaKeysToPtrs(keys []ecdsa.PublicKey) []*ecdsa.PublicKey {
 //
 // Each element of the resulting slice is a serialized compressed public key. See [elliptic.MarshalCompressed].
 // Use [neofsecdsa.PublicKey.Decode] to decode it into a type-specific structure.
+//
+// The value returned shares memory with the structure itself, so changing it can lead to data corruption.
+// Make a copy if you need to change it.
 func (t *Target) BinaryKeys() [][]byte {
 	return t.keys
 }

--- a/netmap/netmap.go
+++ b/netmap/netmap.go
@@ -80,7 +80,8 @@ func (m *NetMap) SetNodes(nodes []NodeInfo) {
 
 // Nodes returns nodes set using SetNodes.
 //
-// Return value MUST not be mutated, make a copy first.
+// The value returned shares memory with the structure itself, so changing it can lead to data corruption.
+// Make a copy if you need to change it.
 func (m NetMap) Nodes() []NodeInfo {
 	return m.nodes
 }
@@ -172,6 +173,9 @@ func (m NetMap) PlacementVectors(vectors [][]NodeInfo, objectID oid.ID) ([][]Nod
 // node order in each vector may vary for call.
 //
 // Result can be used in PlacementVectors.
+//
+// The value returned shares memory with the structure itself, so changing it can lead to data corruption.
+// Make a copy if you need to change it.
 func (m NetMap) ContainerNodes(p PlacementPolicy, containerID cid.ID) ([][]NodeInfo, error) {
 	c := newContext(m)
 	c.setCBF(p.backupFactor)

--- a/netmap/network_info.go
+++ b/netmap/network_info.go
@@ -240,10 +240,11 @@ func (x *NetworkInfo) SetRawNetworkParameter(name string, value []byte) {
 	x.setConfig(name, value)
 }
 
-// RawNetworkParameter reads raw network parameter set using SetRawNetworkParameter
+// RawNetworkParameter reads raw network parameter set using [NetworkInfo.SetRawNetworkParameter]
 // by its name. Returns nil if value is missing.
 //
-// Return value MUST NOT be mutated, make a copy first.
+// The value returned shares memory with the structure itself, so changing it can lead to data corruption.
+// Make a copy if you need to change it.
 //
 // Zero NetworkInfo has no network parameters.
 func (x *NetworkInfo) RawNetworkParameter(name string) []byte {

--- a/netmap/node_info.go
+++ b/netmap/node_info.go
@@ -164,7 +164,8 @@ func (x *NodeInfo) SetPublicKey(key []byte) {
 // The resulting slice of bytes is a serialized compressed public key. See [elliptic.MarshalCompressed].
 // Use [neofsecdsa.PublicKey.Decode] to decode it into a type-specific structure.
 //
-// Return value MUST not be mutated, make a copy first.
+// The value returned shares memory with the structure itself, so changing it can lead to data corruption.
+// Make a copy if you need to change it.
 func (x NodeInfo) PublicKey() []byte {
 	return x.m.GetPublicKey()
 }

--- a/object/attribute.go
+++ b/object/attribute.go
@@ -64,6 +64,9 @@ func (a *Attribute) SetValue(v string) {
 // ToV2 converts [Attribute] to v2 [object.Attribute] message.
 //
 // Nil [Attribute] converts to nil.
+//
+// The value returned shares memory with the structure itself, so changing it can lead to data corruption.
+// Make a copy if you need to change it.
 func (a *Attribute) ToV2() *object.Attribute {
 	return (*object.Attribute)(a)
 }

--- a/object/object.go
+++ b/object/object.go
@@ -55,6 +55,9 @@ func New() *Object {
 }
 
 // ToV2 converts [Object] to v2 [object.Object] message.
+//
+// The value returned shares memory with the structure itself, so changing it can lead to data corruption.
+// Make a copy if you need to change it.
 func (o *Object) ToV2() *object.Object {
 	return (*object.Object)(o)
 }
@@ -151,6 +154,9 @@ func (o *Object) SetSignature(v *neofscrypto.Signature) {
 }
 
 // Payload returns payload bytes.
+//
+// The value returned shares memory with the structure itself, so changing it can lead to data corruption.
+// Make a copy if you need to change it.
 //
 // See also [Object.SetPayload].
 func (o *Object) Payload() []byte {
@@ -338,6 +344,9 @@ func (o *Object) SetPayloadHomomorphicHash(v checksum.Checksum) {
 
 // Attributes returns all object attributes.
 //
+// The value returned shares memory with the structure itself, so changing it can lead to data corruption.
+// Make a copy if you need to change it.
+//
 // See also [Object.SetAttributes], [Object.UserAttributes].
 func (o *Object) Attributes() []Attribute {
 	attrs := (*object.Object)(o).
@@ -354,6 +363,9 @@ func (o *Object) Attributes() []Attribute {
 }
 
 // UserAttributes returns user attributes of the Object.
+//
+// The value returned shares memory with the structure itself, so changing it can lead to data corruption.
+// Make a copy if you need to change it.
 //
 // See also [Object.SetAttributes], [Object.Attributes].
 func (o *Object) UserAttributes() []Attribute {
@@ -675,7 +687,8 @@ func (o *Object) SetType(v Type) {
 
 // CutPayload returns [Object] w/ empty payload.
 //
-// Changes of non-payload fields affect source object.
+// The value returned shares memory with the structure itself, so changing it can lead to data corruption.
+// Make a copy if you need to change it.
 func (o *Object) CutPayload() *Object {
 	ov2 := new(object.Object)
 	*ov2 = *(*object.Object)(o)

--- a/object/range.go
+++ b/object/range.go
@@ -26,6 +26,9 @@ func NewRange() *Range {
 // ToV2 converts [Range] to v2 [object.Range] message.
 //
 // Nil [Range] converts to nil.
+//
+// The value returned shares memory with the structure itself, so changing it can lead to data corruption.
+// Make a copy if you need to change it.
 func (r *Range) ToV2() *object.Range {
 	return (*object.Range)(r)
 }

--- a/object/splitinfo.go
+++ b/object/splitinfo.go
@@ -32,11 +32,17 @@ func NewSplitInfo() *SplitInfo {
 // ToV2 converts [SplitInfo] to v2 [object.SplitInfo] message.
 //
 // Nil SplitInfo converts to nil.
+//
+// The value returned shares memory with the structure itself, so changing it can lead to data corruption.
+// Make a copy if you need to change it.
 func (s *SplitInfo) ToV2() *object.SplitInfo {
 	return (*object.SplitInfo)(s)
 }
 
 // SplitID returns [SplitID] if it has been set.
+//
+// The value returned shares memory with the structure itself, so changing it can lead to data corruption.
+// Make a copy if you need to change it.
 //
 // See also [SplitInfo.SetSplitID].
 func (s *SplitInfo) SplitID() *SplitID {

--- a/object/tombstone.go
+++ b/object/tombstone.go
@@ -29,6 +29,9 @@ func NewTombstone() *Tombstone {
 // ToV2 converts [Tombstone] to v2 [tombstone.Tombstone] message.
 //
 // Nil [Tombstone] converts to nil.
+//
+// The value returned shares memory with the structure itself, so changing it can lead to data corruption.
+// Make a copy if you need to change it.
 func (t *Tombstone) ToV2() *tombstone.Tombstone {
 	return (*tombstone.Tombstone)(t)
 }
@@ -48,6 +51,9 @@ func (t *Tombstone) SetExpirationEpoch(v uint64) {
 }
 
 // SplitID returns identifier of object split hierarchy.
+//
+// The value returned shares memory with the structure itself, so changing it can lead to data corruption.
+// Make a copy if you need to change it.
 //
 // See also [Tombstone.SetSplitID].
 func (t *Tombstone) SplitID() *SplitID {

--- a/reputation/peer.go
+++ b/reputation/peer.go
@@ -63,7 +63,8 @@ func (x *PeerID) SetPublicKey(key []byte) {
 // The resulting slice of bytes is a serialized compressed public key. See [elliptic.MarshalCompressed].
 // Use [neofsecdsa.PublicKey.Decode] to decode it into a type-specific structure.
 //
-// Return value MUST NOT be mutated, make a copy first.
+// The value returned shares memory with the structure itself, so changing it can lead to data corruption.
+// Make a copy if you need to change it.
 func (x PeerID) PublicKey() []byte {
 	return x.m.GetPublicKey()
 }

--- a/stat/statistic.go
+++ b/stat/statistic.go
@@ -17,6 +17,9 @@ func (s Statistic) OverallErrors() uint64 {
 }
 
 // Nodes returns list of nodes statistic.
+//
+// The value returned shares memory with the structure itself, so changing it can lead to data corruption.
+// Make a copy if you need to change it.
 func (s Statistic) Nodes() []NodeStatistic {
 	return s.nodes
 }

--- a/user/id.go
+++ b/user/id.go
@@ -69,7 +69,8 @@ func (x *ID) SetScriptHash(scriptHash util.Uint160) {
 
 // WalletBytes returns NeoFS user ID as Neo3 wallet address in a binary format.
 //
-// Return value MUST NOT be mutated: to do this, first make a copy.
+// The value returned shares memory with the structure itself, so changing it can lead to data corruption.
+// Make a copy if you need to change it.
 //
 // See also Neo3 wallet docs.
 func (x ID) WalletBytes() []byte {


### PR DESCRIPTION
Marked method which returning value must not be changed, because it leads to data malfunction. Left as is places where we create a new var and return it by pointer. Such var mutation is safe for our structs.

closes #187