### PR TITLE
netmap: Extend `NodeInfo` type with verified nodes' domain

### DIFF
--- a/netmap/example_test.go
+++ b/netmap/example_test.go
@@ -1,6 +1,8 @@
 package netmap_test
 
 import (
+	"fmt"
+
 	apiGoNetmap "github.com/nspcc-dev/neofs-api-go/v2/netmap"
 	"github.com/nspcc-dev/neofs-sdk-go/netmap"
 )
@@ -19,4 +21,22 @@ func ExampleNodeInfo_marshalling() {
 	// On the server side.
 
 	_ = info.ReadFromV2(msg)
+}
+
+// When forming information about storage node to be registered the NeoFS
+// network, the node may be optionally associated with some private group of
+// storage nodes in the network. The groups are managed by their owners in
+// corresponding NeoFS NNS domains.
+func ExampleNodeInfo_SetVerifiedNodesDomain() {
+	var bNodePublicKey []byte
+
+	var n netmap.NodeInfo
+	n.SetPublicKey(bNodePublicKey)
+	// other info
+	n.SetVerifiedNodesDomain("nodes.some-org.neofs")
+	// to be allowed into the network, set public key must be in the access list
+	// managed in the specified domain
+
+	// the specified domain is later processed by the system
+	fmt.Printf("Verified nodes' domain: %s\n", n.VerifiedNodesDomain())
 }

--- a/netmap/node_info.go
+++ b/netmap/node_info.go
@@ -532,3 +532,32 @@ func (x *NodeInfo) SetMaintenance() {
 func (x NodeInfo) IsMaintenance() bool {
 	return x.m.GetState() == netmap.Maintenance
 }
+
+const attrVerifiedNodesDomain = "VerifiedNodesDomain"
+
+// SetVerifiedNodesDomain sets optional NeoFS NNS domain name to be used to
+// confirm admission to a storage nodes' group on registration in the NeoFS
+// network of a storage node submitting this NodeInfo about itself. If domain is
+// specified, the storage node requesting entry into the NeoFS network map with
+// must be included in the access list located on the specified domain. The
+// access list is represented by a set of TXT records: Neo script hashes from
+// public keys. To be admitted to the network, script hash of the
+// [NodeInfo.PublicKey] must be present in domain records. Otherwise,
+// registration will be denied. By default, this check is not carried out.
+//
+// Value MUST be a valid NeoFS NNS domain name.
+//
+// See also [NodeInfo.VerifiedNodesDomain].
+func (x *NodeInfo) SetVerifiedNodesDomain(domain string) {
+	x.SetAttribute(attrVerifiedNodesDomain, domain)
+}
+
+// VerifiedNodesDomain returns optional NeoFS NNS domain name to be used to
+// confirm admission to a storage nodes' group on registration in the NeoFS
+// network of a storage node submitting this NodeInfo about itself. Returns zero
+// value if domain is not specified.
+//
+// See also [NodeInfo.SetVerifiedNodesDomain].
+func (x NodeInfo) VerifiedNodesDomain() string {
+	return x.Attribute(attrVerifiedNodesDomain)
+}

--- a/netmap/node_info_test.go
+++ b/netmap/node_info_test.go
@@ -3,6 +3,7 @@ package netmap
 import (
 	"testing"
 
+	"github.com/nspcc-dev/neofs-api-go/v2/netmap"
 	"github.com/stretchr/testify/require"
 )
 
@@ -58,4 +59,30 @@ func TestNodeInfo_ExternalAddr(t *testing.T) {
 
 	n.SetExternalAddresses(addr[1:]...)
 	require.Equal(t, addr[1:], n.ExternalAddresses())
+}
+
+func TestNodeInfo_SetVerifiedNodesDomain(t *testing.T) {
+	const domain = "example.some-org.neofs"
+	var n NodeInfo
+
+	require.Zero(t, n.VerifiedNodesDomain())
+
+	n.SetVerifiedNodesDomain(domain)
+	require.Equal(t, domain, n.VerifiedNodesDomain())
+
+	var msg netmap.NodeInfo
+	n.WriteToV2(&msg)
+
+	attrFound := false
+	msgAttrs := msg.GetAttributes()
+
+	for i := range msgAttrs {
+		if msgAttrs[i].GetKey() == "VerifiedNodesDomain" {
+			require.False(t, attrFound)
+			attrFound = true
+			require.Equal(t, domain, msgAttrs[i].GetValue())
+		}
+	}
+
+	require.True(t, attrFound)
 }


### PR DESCRIPTION
_Inspired by https://github.com/nspcc-dev/neofs-node/issues/2280_