### PR TITLE
pool: Increase timeout to start NeoFS AIO Docker container for testing

### DIFF
--- a/pool/pool_aio_test.go
+++ b/pool/pool_aio_test.go
@@ -191,8 +191,9 @@ func runTests(_ context.Context, t *testing.T, nodeEndpoint string) {
 
 func createDockerContainer(ctx context.Context, t *testing.T, image string) testcontainers.Container {
 	req := testcontainers.ContainerRequest{
-		Image:        image,
-		WaitingFor:   wait.NewLogStrategy("Serving neofs rest gw").WithStartupTimeout(45 * time.Second),
+		Image: image,
+		// timeout is chosen to have enough time for NeoFS chain deployment from scratch within NeoFS AIO
+		WaitingFor:   wait.NewLogStrategy("Serving neofs rest gw").WithStartupTimeout(2 * time.Minute),
 		Name:         "sdk-poll-tests-" + strconv.FormatInt(time.Now().UnixNano(), 36),
 		Hostname:     "aio_autotest_" + strconv.FormatInt(time.Now().UnixNano(), 36),
 		ExposedPorts: []string{"8080/tcp"},


### PR DESCRIPTION
After recent changes, NeoFS AIO Docker container deploys NeoFS chain (deploy contracts, initial transfers, etc.) from scratch internally. This takes around 60 blocks (`~1m`), so AIO takes more than 1 minute to run. Previous test timeout `45s` was insufficient in practice, causing the test to fail.

Timeout is increased to `2m`. The value is still pretty short, at the same time, failure to succeed within this duration will require an individual review for problems.