### PR TITLE
Revert "client: use bigger TTL, expose it to clients"

### DIFF
--- a/client/common.go
+++ b/client/common.go
@@ -16,11 +16,6 @@ const (
 	fieldNumSigPubKey = 1
 	fieldNumSigVal    = 2
 	fieldNumSigScheme = 3
-
-	// DefaultTTL is a TTL used for NeoFS requests if no other value is
-	// set specifically for a call. It limits the number of hops the
-	// request can transit (see specification for details).
-	DefaultTTL = 8
 )
 
 // groups meta parameters shared between all Client operations.
@@ -125,7 +120,7 @@ func (x contextCall) prepareRequest() {
 	}
 
 	if meta.GetTTL() == 0 {
-		meta.SetTTL(DefaultTTL)
+		meta.SetTTL(2)
 	}
 
 	if meta.GetVersion() == nil {
@@ -142,7 +137,7 @@ func (x contextCall) prepareRequest() {
 func (c *Client) prepareRequest(req request, meta *v2session.RequestMetaHeader) {
 	ttl := meta.GetTTL()
 	if ttl == 0 {
-		ttl = DefaultTTL
+		ttl = 2
 	}
 
 	verV2 := meta.GetVersion()


### PR DESCRIPTION
This reverts commit 021cdfa20920fbda30eb90dc532d48eca78f2c82 because it strangely breaks our communication right now, see
https://github.com/nspcc-dev/neofs-node/issues/2768