### PR TITLE
object/filters: Add filtering by first object ID

### DIFF
--- a/object/search.go
+++ b/object/search.go
@@ -134,6 +134,7 @@ const (
 	FilterPayloadHomomorphicHash = v2object.FilterHeaderHomomorphicHash
 	FilterParentID               = v2object.FilterHeaderParent
 	FilterSplitID                = v2object.FilterHeaderSplitID
+	FilterFirstSplitObject       = v2object.ReservedFilterPrefix + "split.first"
 	FilterCreationEpoch          = v2object.FilterHeaderCreationEpoch
 	FilterPayloadSize            = v2object.FilterHeaderPayloadLength
 )
@@ -294,6 +295,13 @@ func (f *SearchFilters) AddObjectIDFilter(m SearchMatchType, id oid.ID) {
 // The m must not be numeric (like [MatchNumGT]).
 func (f *SearchFilters) AddSplitIDFilter(m SearchMatchType, id SplitID) {
 	f.addFilter(m, FilterSplitID, staticStringer(id.String()))
+}
+
+// AddFirstSplitObjectFilter adds filter by first object ID.
+//
+// The m must not be numeric (like [MatchNumGT]).
+func (f *SearchFilters) AddFirstSplitObjectFilter(m SearchMatchType, id oid.ID) {
+	f.addFilter(m, FilterFirstSplitObject, staticStringer(id.String()))
 }
 
 // AddTypeFilter adds filter by object type.

--- a/object/search_test.go
+++ b/object/search_test.go
@@ -218,6 +218,29 @@ func TestSearchFilters_AddSplitIDFilter(t *testing.T) {
 	})
 }
 
+func TestSearchFilters_AddFirstIDFilter(t *testing.T) {
+	id := testOID()
+
+	fs := new(object.SearchFilters)
+	fs.AddFirstSplitObjectFilter(object.MatchStringEqual, id)
+
+	f := (*fs)[0]
+
+	require.Equal(t, object.FilterFirstSplitObject, f.Header())
+	require.Equal(t, id.String(), f.Value())
+	require.Equal(t, object.MatchStringEqual, f.Operation())
+
+	t.Run("v2", func(t *testing.T) {
+		fsV2 := fs.ToV2()
+
+		require.Len(t, fsV2, 1)
+
+		require.Equal(t, v2object.ReservedFilterPrefix+"split.first", fsV2[0].GetKey())
+		require.Equal(t, id.String(), fsV2[0].GetValue())
+		require.Equal(t, v2object.MatchStringEqual, fsV2[0].GetMatchType())
+	})
+}
+
 func TestSearchFilters_AddTypeFilter(t *testing.T) {
 	typ := object.TypeTombstone
 


### PR DESCRIPTION
This field appeared for V2 split first and was not required at first glance. More use cases have been landed now. Also, it is a successor to the SplitID in the V1 split that does have a filter.

API go repo is accepted for archival so no additional const importing for now, will be fixed somehow with removing `neofs-api-go` from go.mod.