### PR TITLE
pool: Fix AIO test

### DIFF
--- a/pool/pool_aio_test.go
+++ b/pool/pool_aio_test.go
@@ -723,7 +723,7 @@ func testCreateContainer(ctx context.Context, t *testing.T, signer neofscrypto.S
 
 	var pp netmap.PlacementPolicy
 	pp.SetContainerBackupFactor(1)
-	pp.SetReplicas(rd)
+	pp.SetReplicas([]netmap.ReplicaDescriptor{rd})
 
 	cont.SetPlacementPolicy(pp)
 


### PR DESCRIPTION
now it builds, but my local run failed with `TestPoolAio/nspccdev/neofs-aio:latest: failed to start container`