### PR TITLE
netmap: export `ErrNotEnoughNodes`

### DIFF
--- a/netmap/context.go
+++ b/netmap/context.go
@@ -39,12 +39,15 @@ type context struct {
 
 // Various validation errors.
 var (
+	// ErrNotEnoughNodes is returned when a placement policy cannot be satisfied
+	// due to low numbers of nodes in selected network map.
+	ErrNotEnoughNodes = errors.New("not enough nodes to SELECT from")
+
 	errInvalidFilterName = errors.New("filter name is invalid")
 	errInvalidNumber     = errors.New("invalid number")
 	errInvalidFilterOp   = errors.New("invalid filter operation")
 	errFilterNotFound    = errors.New("filter not found")
 	errNonEmptyFilters   = errors.New("simple filter contains sub-filters")
-	errNotEnoughNodes    = errors.New("not enough nodes to SELECT from")
 	errUnnamedTopFilter  = errors.New("unnamed top-level filter")
 )
 

--- a/netmap/netmap.go
+++ b/netmap/netmap.go
@@ -176,6 +176,9 @@ func (m NetMap) PlacementVectors(vectors [][]NodeInfo, objectID oid.ID) ([][]Nod
 //
 // The value returned shares memory with the structure itself, so changing it can lead to data corruption.
 // Make a copy if you need to change it.
+//
+// Returns ErrNotEnoughNodes if placement policy cannot be satisfied in the
+// current network map because of a lack of container nodes.
 func (m NetMap) ContainerNodes(p PlacementPolicy, containerID cid.ID) ([][]NodeInfo, error) {
 	c := newContext(m)
 	c.setCBF(p.backupFactor)

--- a/netmap/selector.go
+++ b/netmap/selector.go
@@ -61,7 +61,7 @@ func (c *context) getSelection(_ PlacementPolicy, s netmap.Selector) ([]nodes, e
 	buckets := c.getSelectionBase(s)
 
 	if len(buckets) < bucketCount {
-		return nil, fmt.Errorf("%w: '%s'", errNotEnoughNodes, s.GetName())
+		return nil, fmt.Errorf("%w: '%s'", ErrNotEnoughNodes, s.GetName())
 	}
 
 	// We need deterministic output in case there is no pivot.
@@ -97,7 +97,7 @@ func (c *context) getSelection(_ PlacementPolicy, s netmap.Selector) ([]nodes, e
 		// Fallback to using minimum allowed backup factor (1).
 		res = append(res, fallback...)
 		if len(res) < bucketCount {
-			return nil, fmt.Errorf("%w: '%s'", errNotEnoughNodes, s.GetName())
+			return nil, fmt.Errorf("%w: '%s'", ErrNotEnoughNodes, s.GetName())
 		}
 	}
 


### PR DESCRIPTION
It can be a problem to distinguish this error in cases when it is not a real problem (e.g., checking if a node belongs to a container).