### PR TITLE
workflows: run tests for master

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,11 @@
 name: neofs-sdk-go tests
 
 on:
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - '**/*.md'
   pull_request:
     branches:
       - master


### PR DESCRIPTION
Sometimes merged code != PR code and we want to have some proper statistics for covertage as well (it doesn't have proper data for master now because we're not collecting it).