### PR TITLE
session: Prevent panic of AssertAuthKey method on nil public key

### DIFF
--- a/session/common.go
+++ b/session/common.go
@@ -330,13 +330,14 @@ func (x *commonData) SetIssuer(id user.ID) {
 	x.issuer = id
 }
 
-// AssertAuthKey asserts public key bound to the session.
+// AssertAuthKey asserts public key bound to the session. The key should not be
+// nil.
 //
 // Zero session fails the check.
 //
 // See also SetAuthKey.
 func (x commonData) AssertAuthKey(key neofscrypto.PublicKey) bool {
-	return bytes.Equal(neofscrypto.PublicKeyBytes(key), x.authKey)
+	return key != nil && bytes.Equal(neofscrypto.PublicKeyBytes(key), x.authKey)
 }
 
 // Issuer returns user ID of the session issuer.

--- a/session/common_test.go
+++ b/session/common_test.go
@@ -266,6 +266,7 @@ func testSetAuthKey[T session.Container | session.Object](t testing.TB, set func
 	k1 := neofscryptotest.Signer().Public()
 	k2 := neofscryptotest.Signer().Public()
 	var x T
+	require.False(t, assert(x, nil))
 	require.False(t, assert(x, k1))
 	require.False(t, assert(x, k2))
 


### PR DESCRIPTION
after lib upgrade within https://github.com/nspcc-dev/neofs-node/pull/3005, some issues appeared https://github.com/nspcc-dev/neofs-node/pull/3005#issuecomment-2483371807. Here are insta fixes for them