### PR TITLE
pool: Fix unsafe randomizers

### DIFF
--- a/pool/pool.go
+++ b/pool/pool.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math/rand"
 	"sort"
 	"sync"
 	"sync/atomic"
@@ -769,8 +768,7 @@ func (p *Pool) Dial(ctx context.Context) error {
 
 			atLeastOneHealthy = true
 		}
-		source := rand.NewSource(time.Now().UnixNano())
-		sampl := newSampler(params.weights, source)
+		sampl := newSampler(params.weights, safeRand{})
 
 		inner[i] = &innerPool{
 			sampler: sampl,
@@ -940,9 +938,8 @@ func (p *Pool) updateInnerNodesHealth(ctx context.Context, i int, bufferWeights 
 
 	if healthyChanged.Load() {
 		probabilities := adjustWeights(bufferWeights)
-		source := rand.NewSource(time.Now().UnixNano())
 		pool.lock.Lock()
-		pool.sampler = newSampler(probabilities, source)
+		pool.sampler = newSampler(probabilities, safeRand{})
 		pool.lock.Unlock()
 	}
 }

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -985,7 +985,7 @@ func (p *innerPool) connection() (internalClient, error) {
 	}
 	attempts := 3 * len(p.clients)
 	for range attempts {
-		i := p.sampler.Next()
+		i := p.sampler.next()
 		if cp := p.clients[i]; cp.isHealthy() {
 			return cp, nil
 		}

--- a/pool/sampler.go
+++ b/pool/sampler.go
@@ -57,8 +57,8 @@ func newSampler(probabilities []float64, source rand.Source) *sampler {
 	return sampler
 }
 
-// Next returns the next (not so) random number from sampler.
-func (g *sampler) Next() int {
+// returns the next (not so) random number from sampler.
+func (g *sampler) next() int {
 	n := len(g.alias)
 	i := g.randomGenerator.Intn(n)
 	if g.randomGenerator.Float64() < g.probabilities[i] {

--- a/pool/sampler_test.go
+++ b/pool/sampler_test.go
@@ -35,7 +35,7 @@ func TestSamplerStability(t *testing.T) {
 		sampler := newSampler(tc.probabilities, rand.NewSource(0))
 		res := make([]int, len(tc.probabilities))
 		for range COUNT {
-			res[sampler.Next()]++
+			res[sampler.next()]++
 		}
 
 		require.Equal(t, tc.expected, res, "probabilities: %v", tc.probabilities)

--- a/pool/sampler_test.go
+++ b/pool/sampler_test.go
@@ -36,7 +36,7 @@ func TestSamplerStability(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		sampler := newSampler(tc.probabilities, rand.NewSource(0))
+		sampler := newSampler(tc.probabilities, rand.New(rand.NewSource(0)))
 		res := make([]int, len(tc.probabilities))
 		for range COUNT {
 			res[sampler.next()]++
@@ -62,7 +62,7 @@ func TestHealthyReweight(t *testing.T) {
 	client2 := newMockClient(names[1], neofscryptotest.Signer())
 
 	inner := &innerPool{
-		sampler: newSampler(weights, rand.NewSource(0)),
+		sampler: newSampler(weights, rand.New(rand.NewSource(0))),
 		clients: []internalClient{client1, client2},
 	}
 	p := &Pool{
@@ -91,7 +91,7 @@ func TestHealthyReweight(t *testing.T) {
 	inner.lock.Unlock()
 
 	p.updateInnerNodesHealth(context.TODO(), 0, buffer)
-	inner.sampler = newSampler(weights, rand.NewSource(0))
+	inner.sampler = newSampler(weights, rand.New(rand.NewSource(0)))
 
 	connection0, err = p.connection()
 	require.NoError(t, err)
@@ -106,7 +106,7 @@ func TestHealthyNoReweight(t *testing.T) {
 		buffer  = make([]float64, len(weights))
 	)
 
-	sampl := newSampler(weights, rand.NewSource(0))
+	sampl := newSampler(weights, rand.New(rand.NewSource(0)))
 	inner := &innerPool{
 		sampler: sampl,
 		clients: []internalClient{
@@ -134,7 +134,7 @@ func TestSamplerSafety(t *testing.T) {
 		cause any
 		stack []byte
 	}
-	s := newSampler([]float64{0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1}, rand.NewSource(0))
+	s := newSampler([]float64{0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1}, safeRand{})
 	var pr atomic.Value // panicInfo
 	var wg sync.WaitGroup
 	for range 1000 {
@@ -163,7 +163,7 @@ func TestSamplerSafety(t *testing.T) {
 }
 
 func BenchmarkSampler(b *testing.B) {
-	s := newSampler([]float64{0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1}, rand.NewSource(0))
+	s := newSampler([]float64{0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1}, safeRand{})
 	for range b.N {
 		s.next()
 	}

--- a/pool/sampler_test.go
+++ b/pool/sampler_test.go
@@ -161,3 +161,10 @@ func TestSamplerSafety(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkSampler(b *testing.B) {
+	s := newSampler([]float64{0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1}, rand.NewSource(0))
+	for range b.N {
+		s.next()
+	}
+}


### PR DESCRIPTION
we can also just mutex the panicking part, safe `rand` functions do the same