### PR TITLE
client: set OID in object returned from Head()

### DIFF
--- a/client/object_get.go
+++ b/client/object_get.go
@@ -482,6 +482,7 @@ func (c *Client) ObjectHead(ctx context.Context, containerID cid.ID, objectID oi
 
 		var obj object.Object
 		if err = obj.FromProtoMessage(&protoobject.Object{
+			ObjectId:  objectID.ProtoMessage(),
 			Signature: v.Header.Signature,
 			Header:    v.Header.Header,
 		}); err != nil {


### PR DESCRIPTION
3c47093ae4c28b62afba3e3f34bb270d39cf3137 regression. Even though it's not a part of the protocol, clients expect it to be set.