### PR TITLE
client: make Dial follow the timeout parameter

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -191,7 +191,7 @@ func (c *Client) Dial(prm PrmDial) error {
 	c.reputation = protoreputation.NewReputationServiceClient(c.conn)
 	c.session = protosession.NewSessionServiceClient(c.conn)
 
-	endpointInfo, err := c.EndpointInfo(prm.parentCtx, PrmEndpointInfo{})
+	endpointInfo, err := c.EndpointInfo(ctx, PrmEndpointInfo{})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
DialContext calls NewClient and it's specified to perform no I/O at all, so we don't know whether the node is alive or not. We're querying network info from it to ensure it's OK, but this request uses parent context, so it takes some unknown time instead of a proper dial timeout.