### PR TITLE
object/slicer: Do not override object owner with bearer token issuer

### DIFF
--- a/object/slicer/slicer.go
+++ b/object/slicer/slicer.go
@@ -270,10 +270,6 @@ func initPayloadStream(ctx context.Context, ow ObjectWriter, header object.Objec
 		header.SetOwner(owner)
 	} else if opts.bearerToken != nil {
 		prm.WithBearerToken(*opts.bearerToken)
-		// token issuer is a container owner.
-		issuer := opts.bearerToken.Issuer()
-		owner = issuer
-		header.SetOwner(owner)
 	}
 
 	header.SetCreationEpoch(opts.currentNeoFSEpoch)


### PR DESCRIPTION
* caught while testing https://github.com/nspcc-dev/neofs-node/pull/3305