### PR TITLE
client: fix incorrect gRPC buffer pool use

### DIFF
--- a/client/common.go
+++ b/client/common.go
@@ -69,7 +69,7 @@ func (x onlyBinarySendingCodec) Name() string {
 func (x onlyBinarySendingCodec) Marshal(msg any) (mem.BufferSlice, error) {
 	bMsg, ok := msg.([]byte)
 	if ok {
-		return mem.BufferSlice{mem.NewBuffer(&bMsg, mem.DefaultBufferPool())}, nil
+		return mem.BufferSlice{mem.SliceBuffer(bMsg)}, nil
 	}
 
 	return nil, fmt.Errorf("message is not of type %T", bMsg)


### PR DESCRIPTION
NewBuffer() implies some pooled buffers and DefaultBufferPool is exactly that -- the default pool where buffers are put after use. This means that any given slice of data will end up there and then could be reused for any other gRPC-related purpose. This is not something users of client package can expect, so unexpected memory corruptions are quite possible.

Regression of b7f8cd08340176bd9f58fe030e137d29fd627201.