### PR TITLE
Support unsigned object GET/HEAD responses

### DIFF
--- a/client/object_get.go
+++ b/client/object_get.go
@@ -11,6 +11,7 @@ import (
 	apistatus "github.com/nspcc-dev/neofs-sdk-go/client/status"
 	cid "github.com/nspcc-dev/neofs-sdk-go/container/id"
 	neofscrypto "github.com/nspcc-dev/neofs-sdk-go/crypto"
+	neofsproto "github.com/nspcc-dev/neofs-sdk-go/internal/proto"
 	"github.com/nspcc-dev/neofs-sdk-go/object"
 	oid "github.com/nspcc-dev/neofs-sdk-go/object/id"
 	protoobject "github.com/nspcc-dev/neofs-sdk-go/proto/object"
@@ -481,6 +482,12 @@ func (c *Client) ObjectHead(ctx context.Context, containerID cid.ID, objectID oi
 		}); err != nil {
 			return nil, fmt.Errorf("invalid header response: %w", err)
 		}
+
+		hb := neofsproto.MarshalMessage(v.Header.Header)
+		if oid.NewFromObjectHeaderBinary(hb) != objectID {
+			return nil, errors.New("received header mismatches ID")
+		}
+
 		return &obj, nil
 	}
 }

--- a/client/object_get.go
+++ b/client/object_get.go
@@ -99,11 +99,6 @@ func (x *PayloadReader) readHeader(dst *object.Object) bool {
 		return false
 	}
 
-	if x.err = neofscrypto.VerifyResponseWithBuffer[*protoobject.GetResponse_Body](resp, nil); x.err != nil {
-		x.err = fmt.Errorf("%w: %w", errResponseSignatures, x.err)
-		return false
-	}
-
 	if x.err = apistatus.ToError(resp.GetMetaHeader().GetStatus()); x.err != nil {
 		return false
 	}
@@ -180,11 +175,6 @@ func (x *PayloadReader) readChunk(buf []byte) (int, bool) {
 			return err
 		})
 		if x.err != nil {
-			return read, false
-		}
-
-		if x.err = neofscrypto.VerifyResponseWithBuffer[*protoobject.GetResponse_Body](resp, nil); x.err != nil {
-			x.err = fmt.Errorf("%w: %w", errResponseSignatures, x.err)
 			return read, false
 		}
 
@@ -447,11 +437,6 @@ func (c *Client) ObjectHead(ctx context.Context, containerID cid.ID, objectID oi
 	resp, err := c.object.Head(ctx, req)
 	if err != nil {
 		err = rpcErr(err)
-		return nil, err
-	}
-
-	if err = neofscrypto.VerifyResponseWithBuffer[*protoobject.HeadResponse_Body](resp, *buf); err != nil {
-		err = fmt.Errorf("%w: %w", errResponseSignatures, err)
 		return nil, err
 	}
 

--- a/client/object_get_test.go
+++ b/client/object_get_test.go
@@ -754,6 +754,13 @@ func TestClient_ObjectHead(t *testing.T) {
 		otherID := oidtest.OtherID(anyOID)
 		_, err = c.ObjectHead(ctx, anyCID, otherID, anyValidSigner, anyValidOpts)
 		require.EqualError(t, err, "received header mismatches ID")
+
+		t.Run("skip", func(t *testing.T) {
+			opts := anyValidOpts
+			opts.SkipChecksumVerification()
+			_, err = c.ObjectHead(ctx, anyCID, otherID, anyValidSigner, opts)
+			require.NoError(t, err)
+		})
 	})
 }
 

--- a/proto/netmap/types.pb.go
+++ b/proto/netmap/types.pb.go
@@ -953,7 +953,7 @@ func (x *NodeInfo_Attribute) GetParents() []string {
 //     Number of EigenTrust algorithm iterations to pass in the Reputation system.
 //     Value: little-endian integer. Default: 0.
 //   - **EpochDuration** \
-//     NeoFS epoch duration measured in FS chain blocks.
+//     NeoFS epoch duration measured in seconds.
 //     Value: little-endian integer. Default: 0.
 //   - **HomomorphicHashingDisabled** \
 //     Flag of disabling the homomorphic hashing of objects' payload.

--- a/proto/object/service.pb.go
+++ b/proto/object/service.pb.go
@@ -102,6 +102,8 @@ type GetResponse struct {
 	// Carries response verification information. This header is used to
 	// authenticate the nodes of the message route and check the correctness of
 	// transmission.
+	// DEPRECATED: Verify header and payload checksums instead. Servers MUST
+	// attach it for requests with `meta_header.version` <= 2.17.
 	VerifyHeader  *session.ResponseVerificationHeader `protobuf:"bytes,3,opt,name=verify_header,json=verifyHeader,proto3" json:"verify_header,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -566,6 +568,8 @@ type HeadResponse struct {
 	// Carries response verification information. This header is used to
 	// authenticate the nodes of the message route and check the correctness of
 	// transmission.
+	// DEPRECATED: Verify header and payload checksums instead. Servers MUST
+	// attach it for requests with `meta_header.version` <= 2.17.
 	VerifyHeader  *session.ResponseVerificationHeader `protobuf:"bytes,3,opt,name=verify_header,json=verifyHeader,proto3" json:"verify_header,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache


### PR DESCRIPTION
* based on and blocked by https://github.com/nspcc-dev/neofs-api/pull/334