### PR TITLE
README: drop obsolete and long gone packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,21 +21,8 @@ There is also a reference implementation of checking algorithm which is used in 
 Contains `Checksum` type encapsulating checksum as well as it's kind.
 Currently Sha256 and [Tillich-Zemor hashsum](https://github.com/nspcc-dev/tzhash) are in use.
 
-### owner
-`owner.ID` type represents single account interacting with NeoFS. In v2 version of protocol
-it is just raw bytes behing [base58-encoded address](https://docs.neo.org/docs/en-us/basic/concept/wallets.html#address)
-in Neo blockchain. Note that for historical reasons it contains
-version prefix and checksum in addition to script-hash.
-
-### token
+### bearer
 Contains Bearer token type with several NeoFS-specific methods.
-
-### ns
-In NeoFS there are 2 types of name resolution: DNS and NNS. NNS stands for Neo Name Service
-is just a [contract](https://github.com/nspcc-dev/neofs-contract/) deployed on a Neo blockchain.
-Basically, NNS is just a DNS-on-chain which can be used for resolving container nice-names as well
-as any other name in dApps. See our [CoreDNS plugin](https://github.com/nspcc-dev/coredns/tree/master/plugin/nns)
-for the example of how NNS can be integrated in DNS.
 
 ### session
 To help lightweight clients interact with NeoFS without sacrificing trust, NeoFS has a concept
@@ -85,19 +72,6 @@ Status wire-format is extendable and each node can report any set of details it 
 The set of reserved status codes can be found in
 [NeoFS API](https://github.com/nspcc-dev/neofs-api/blob/master/status/types.proto).
 
-### policy
-Contains helpers allowing conversion of placing policy from/to JSON representation
-and SQL-like human-readable language.
-```go
-p, _ := policy.Parse(`
-    REP 2
-    SELECT 6 FROM F
-    FILTER StorageType EQ SSD AS F`)
-
-// Convert parsed policy back to human-readable text and print.
-println(strings.Join(policy.Encode(p), "\n"))
-```
-
 ### netmap
 Contains CRUSH-like implementation of container node selection algorithm. Relevant details
 are described in this paper http://ceur-ws.org/Vol-2344/short10.pdf . Note that it can be
@@ -129,14 +103,8 @@ func placementNodes(addr *object.Address, p *netmap.PlacementPolicy, neofsNodes 
 ### pool
 Simple pool for managing connections to NeoFS nodes.
 
-### acl, checksum, version, signature
+### checksum, version
 Contain simple API wrappers.
-
-### logger
-Wrapper over `zap.Logger` which is used across NeoFS codebase.
-
-### util
-Utilities for working with signature-related code.
 
 ## Development
 


### PR DESCRIPTION
Maybe we can just refer to pkg.go.dev?