### PR TITLE
Expose NodeInfo capacity func

### DIFF
--- a/netmap/aggregator.go
+++ b/netmap/aggregator.go
@@ -56,7 +56,7 @@ var (
 // capacity and price.
 func newWeightFunc(capNorm, priceNorm normalizer) weightFunc {
 	return func(n NodeInfo) float64 {
-		return capNorm.Normalize(float64(n.capacity())) * priceNorm.Normalize(float64(n.Price()))
+		return capNorm.Normalize(float64(n.Capacity())) * priceNorm.Normalize(float64(n.Price()))
 	}
 }
 

--- a/netmap/context.go
+++ b/netmap/context.go
@@ -83,7 +83,7 @@ func defaultWeightFunc(ns nodes) weightFunc {
 	minA := newMinAgg()
 
 	for i := range ns {
-		meanA.Add(float64(ns[i].capacity()))
+		meanA.Add(float64(ns[i].Capacity()))
 		minA.Add(float64(ns[i].Price()))
 	}
 

--- a/netmap/filter.go
+++ b/netmap/filter.go
@@ -113,7 +113,7 @@ func (c *context) matchKeyValue(f Filter, b NodeInfo) bool {
 		case attrPrice:
 			attr = b.Price()
 		case attrCapacity:
-			attr = b.capacity()
+			attr = b.Capacity()
 		default:
 			var err error
 

--- a/netmap/node_info.go
+++ b/netmap/node_info.go
@@ -259,10 +259,10 @@ func (x *NodeInfo) SetVersion(version string) {
 	x.SetAttribute(attrVersion, version)
 }
 
-// capacity returns capacity set using SetCapacity.
+// Capacity returns capacity set using SetCapacity.
 //
 // Zero NodeInfo has zero capacity.
-func (x NodeInfo) capacity() uint64 {
+func (x NodeInfo) Capacity() uint64 {
 	val := x.Attribute(attrCapacity)
 	if val == "" {
 		return 0


### PR DESCRIPTION
There are no reasons to keep it private. We cat set it and should be able to read it as well.