### PR TITLE
*: deprecate Tillich-Zémor checksum

### DIFF
--- a/checksum/checksum.go
+++ b/checksum/checksum.go
@@ -29,7 +29,7 @@ type Type int32
 const (
 	_            Type = iota
 	SHA256            // SHA-256 hash
-	TillichZemor      // Tillich-Zémor homomorphic hash
+	TillichZemor      // Tillich-Zémor homomorphic hash. Deprecated.
 )
 
 func typeToProto(t Type) refs.ChecksumType {
@@ -66,6 +66,9 @@ func NewSHA256(h [sha256.Size]byte) Checksum {
 }
 
 // NewTillichZemor constructs new Checksum from Tillich-Zémor homomorphic hash.
+//
+// Deprecated: Tillich-Zémor checksum is not supported for objects starting
+// from API 2.23+.
 func NewTillichZemor(h [tz.Size]byte) Checksum {
 	return New(TillichZemor, h[:])
 }
@@ -123,7 +126,7 @@ func (c Checksum) ProtoMessage() *refs.Checksum {
 //
 // Zero Checksum has Unknown checksum type.
 //
-// See also [NewTillichZemor], [NewSHA256].
+// See also [NewSHA256].
 func (c Checksum) Type() Type {
 	return c.typ
 }
@@ -136,7 +139,7 @@ func (c Checksum) Type() Type {
 // The value returned shares memory with the structure itself, so changing it can lead to data corruption.
 // Make a copy if you need to change it.
 //
-// See also [NewTillichZemor], [NewSHA256].
+// See also [NewSHA256].
 func (c Checksum) Value() []byte {
 	return c.val
 }

--- a/checksum/test/generate.go
+++ b/checksum/test/generate.go
@@ -1,20 +1,17 @@
 package checksumtest
 
 import (
+	"crypto/sha256"
 	"fmt"
-	"math/rand"
 
 	"github.com/nspcc-dev/neofs-sdk-go/checksum"
 	"github.com/nspcc-dev/neofs-sdk-go/internal/testutil"
 )
 
-var allSupportedTypes = []checksum.Type{checksum.SHA256, checksum.TillichZemor}
-
 // Checksum returns random checksum.Checksum.
 func Checksum() checksum.Checksum {
-	data := testutil.RandByteSlice(32)
-	i := rand.Int() % len(allSupportedTypes)
-	res, err := checksum.NewFromData(allSupportedTypes[i], data)
+	data := testutil.RandByteSlice(sha256.Size)
+	res, err := checksum.NewFromData(checksum.SHA256, data)
 	if err != nil {
 		panic(fmt.Errorf("unexpected NewFromData error: %w", err))
 	}

--- a/client/container.go
+++ b/client/container.go
@@ -742,6 +742,8 @@ func (c *Client) ContainerSetEACL(ctx context.Context, table eacl.Table, signer 
 // Returns any network/parsing config errors.
 //
 // See also [client.Client.NetworkInfo], [container.Container.ApplyNetworkConfig].
+//
+// Deprecated: network settings should not affect containers.
 func SyncContainerWithNetwork(ctx context.Context, cnr *container.Container, c NetworkInfoExecutor) error {
 	if cnr == nil {
 		return errors.New("empty container")

--- a/client/messages_test.go
+++ b/client/messages_test.go
@@ -1120,7 +1120,7 @@ func checkContainerTransport(c container.Container, m *protocontainer.Container)
 	if v1, v2 := c.Name(), name; v1 != v2 {
 		return fmt.Errorf("name attribute (client: %q, message: %q)", v1, v2)
 	}
-	if v1, v2 := c.IsHomomorphicHashingDisabled(), disableHomoHash; v2 != v1 {
+	if v1, v2 := c.IsHomomorphicHashingDisabled(), disableHomoHash; v2 != v1 { //nolint:staticcheck // homo containers can still be found
 		return fmt.Errorf("homomorphic hashing flag attribute (client: %t, message: %t)", v1, v2)
 	}
 	if v1, v2 := c.CreatedAt().Unix(), timestamp; v2 != v1 {
@@ -1673,6 +1673,7 @@ func checkObjectHeaderTransport(h object.Object, m *protoobject.Header) error {
 		return fmt.Errorf("type field (client: %v, message %v)", expType, actType)
 	}
 	// 8. payload homomorphic checksum
+	//nolint:staticcheck // homo objects can still be replicated
 	cs, ok = h.PayloadHomomorphicHash()
 	mcs = m.GetHomomorphicHash()
 	if ok {

--- a/client/object_hash.go
+++ b/client/object_hash.go
@@ -61,6 +61,9 @@ func (x *PrmObjectHash) SetRangeList(r ...uint64) {
 // (https://link.springer.com/content/pdf/10.1007/3-540-48658-5_5.pdf).
 //
 // By default, SHA256 hash function is used.
+//
+// Deprecated: this algorithm has been deprecated and should not be used. Its
+// support will be removed eventually.
 func (x *PrmObjectHash) TillichZemorAlgo() {
 	x.tz = true
 }

--- a/container/container.go
+++ b/container/container.go
@@ -440,6 +440,9 @@ const attributeHomoHashEnabled = "true"
 // Container data.
 //
 // See also IsHomomorphicHashingDisabled.
+//
+// Deprecated: Tillich-Zémor checksum is not supported for objects starting
+// from API 2.23+.
 func (x *Container) DisableHomomorphicHashing() {
 	x.SetAttribute(sysAttrDisableHomohash, attributeHomoHashEnabled)
 }
@@ -447,6 +450,9 @@ func (x *Container) DisableHomomorphicHashing() {
 // IsHomomorphicHashingDisabled checks if DisableHomomorphicHashing was called.
 //
 // Zero Container has enabled hashing.
+//
+// Deprecated: Tillich-Zémor checksum is not supported for objects starting
+// from API 2.23+.
 func (x Container) IsHomomorphicHashingDisabled() bool {
 	return x.Attribute(sysAttrDisableHomohash) == attributeHomoHashEnabled
 }

--- a/container/network.go
+++ b/container/network.go
@@ -7,14 +7,21 @@ import (
 // ApplyNetworkConfig applies network configuration to the
 // container. Changes the container if it does not satisfy
 // network configuration.
+//
+// Deprecated: network settings should not affect containers.
 func (x *Container) ApplyNetworkConfig(cfg netmap.NetworkInfo) {
+	//nolint:staticcheck // compatibility
 	if cfg.HomomorphicHashingDisabled() {
+		//nolint:staticcheck
 		x.DisableHomomorphicHashing()
 	}
 }
 
 // AssertNetworkConfig checks if a container matches passed
 // network configuration.
+//
+// Deprecated: network settings should not affect containers.
 func (x Container) AssertNetworkConfig(cfg netmap.NetworkInfo) bool {
+	//nolint:staticcheck // compatibility
 	return x.IsHomomorphicHashingDisabled() == cfg.HomomorphicHashingDisabled()
 }

--- a/container/network_test.go
+++ b/container/network_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+//nolint:staticcheck // homomorphic hash compatibility
 func TestContainer_NetworkConfig(t *testing.T) {
 	c := containertest.Container()
 	nc := netmaptest.NetworkInfo()

--- a/eacl/filter.go
+++ b/eacl/filter.go
@@ -88,7 +88,7 @@ const (
 	FilterObjectPayloadSize                = "$Object:payloadLength"
 	FilterObjectPayloadChecksum            = "$Object:payloadHash"
 	FilterObjectType                       = "$Object:objectType"
-	FilterObjectPayloadHomomorphicChecksum = "$Object:homomorphicHash"
+	FilterObjectPayloadHomomorphicChecksum = "$Object:homomorphicHash" // Deprecated.
 )
 
 func (s staticStringer) EncodeToString() string {

--- a/netmap/network_info.go
+++ b/netmap/network_info.go
@@ -519,6 +519,9 @@ const configHomomorphicHashingDisabled = "HomomorphicHashingDisabled"
 // hashing of the containers in the network.
 //
 // See also HomomorphicHashingDisabled.
+//
+// Deprecated: Tillich-Zémor checksum is not supported for objects starting
+// from API 2.23+.
 func (x *NetworkInfo) DisableHomomorphicHashing() {
 	x.setConfigBool(configHomomorphicHashingDisabled, true)
 }
@@ -527,6 +530,9 @@ func (x *NetworkInfo) DisableHomomorphicHashing() {
 // hashing network setting.
 //
 // Zero NetworkInfo has enabled homomorphic hashing.
+//
+// Deprecated: Tillich-Zémor checksum is not supported for objects starting
+// from API 2.23+.
 func (x NetworkInfo) HomomorphicHashingDisabled() bool {
 	return x.configBool(configHomomorphicHashingDisabled)
 }

--- a/object/object.go
+++ b/object/object.go
@@ -556,6 +556,8 @@ func (o *Object) SetPayloadChecksum(v checksum.Checksum) {
 // Zero [Object] does not have payload homomorphic checksum.
 //
 // See also [Object.SetPayloadHomomorphicHash].
+//
+// Deprecated: API 2.23+ objects must not have homomorphic hash.
 func (o Object) PayloadHomomorphicHash() (checksum.Checksum, bool) {
 	if o.header.pldHomoHash != nil {
 		return *o.header.pldHomoHash, true
@@ -566,6 +568,8 @@ func (o Object) PayloadHomomorphicHash() (checksum.Checksum, bool) {
 // SetPayloadHomomorphicHash sets homomorphic hash of the object payload.
 //
 // See also [Object.PayloadHomomorphicHash].
+//
+// Deprecated: API 2.23+ objects must not have homomorphic hash.
 func (o *Object) SetPayloadHomomorphicHash(v checksum.Checksum) {
 	o.header.pldHomoHash = &v
 }

--- a/object/search.go
+++ b/object/search.go
@@ -138,7 +138,7 @@ const (
 	FilterOwnerID                = reservedFilterPrefix + "ownerID"
 	FilterPayloadChecksum        = reservedFilterPrefix + "payloadHash"
 	FilterType                   = reservedFilterPrefix + "objectType"
-	FilterPayloadHomomorphicHash = reservedFilterPrefix + "homomorphicHash"
+	FilterPayloadHomomorphicHash = reservedFilterPrefix + "homomorphicHash" // Deprecated.
 	FilterParentID               = reservedFilterPrefix + "split.parent"
 	FilterSplitID                = reservedFilterPrefix + "split.splitID"
 	FilterFirstSplitObject       = reservedFilterPrefix + "split.first"
@@ -359,6 +359,9 @@ func (f *SearchFilters) AddPayloadHashFilter(m SearchMatchType, sum [sha256.Size
 // AddHomomorphicHashFilter adds filter by homomorphic hash.
 //
 // The m must not be numeric (like [MatchNumGT]).
+//
+// Deprecated: homomorphic hash is not added to API 2.23+ objects and should
+// not be searched.
 func (f *SearchFilters) AddHomomorphicHashFilter(m SearchMatchType, sum [tz.Size]byte) {
 	f.addFilter(m, FilterPayloadHomomorphicHash, hex.EncodeToString(sum[:]))
 }

--- a/object/search_test.go
+++ b/object/search_test.go
@@ -401,7 +401,7 @@ func TestSearchFilters_AddHomomorphicHashFilter(t *testing.T) {
 
 func ExampleSearchFilters_AddHomomorphicHashFilter() {
 	hash, _ := hex.DecodeString("7e302ebb3937e810feb501965580c746048db99cebd095c3ce27022407408bf904dde8d9aa8085d2cf7202345341cc947fa9d722c6b6699760d307f653815d0c")
-	cs := checksum.NewTillichZemor([tz.Size]byte(hash))
+	cs := checksum.NewTillichZemor([tz.Size]byte(hash)) //nolint:staticcheck // still supported for clients
 	fmt.Println(hex.EncodeToString(cs.Value()))
 	// Output: 7e302ebb3937e810feb501965580c746048db99cebd095c3ce27022407408bf904dde8d9aa8085d2cf7202345341cc947fa9d722c6b6699760d307f653815d0c
 }

--- a/object/slicer/options.go
+++ b/object/slicer/options.go
@@ -39,6 +39,9 @@ func (x *Options) SetCurrentNeoFSEpoch(e uint64) {
 
 // CalculateHomomorphicChecksum makes Slicer to calculate and set homomorphic
 // checksum of the processed objects.
+//
+// Deprecated: homomorphic hashing has been deprecated and should not be used.
+// Its support will be removed eventually.
 func (x *Options) CalculateHomomorphicChecksum() {
 	x.withHomoChecksum = true
 }
@@ -96,6 +99,9 @@ func (x *Options) CurrentNeoFSEpoch() uint64 {
 }
 
 // IsHomomorphicChecksumEnabled indicates homomorphic checksum calculation status.
+//
+// Deprecated: homomorphic hashing has been deprecated and should not be used.
+// Its support will be removed eventually.
 func (x *Options) IsHomomorphicChecksumEnabled() bool {
 	return x.withHomoChecksum
 }

--- a/object/slicer/slicer.go
+++ b/object/slicer/slicer.go
@@ -103,6 +103,7 @@ func New(ctx context.Context, nw NetworkedClient, signer user.Signer, cnr cid.ID
 		sessionTokenV2:     sessionToken,
 	}
 
+	//nolint:staticcheck // compatibility
 	if !ni.HomomorphicHashingDisabled() {
 		opts.CalculateHomomorphicChecksum()
 	}
@@ -138,6 +139,7 @@ func NewWithV1Token(ctx context.Context, nw NetworkedClient, signer user.Signer,
 		sessionToken:       sessionToken,
 	}
 
+	//nolint:staticcheck // compatibility
 	if !ni.HomomorphicHashingDisabled() {
 		opts.CalculateHomomorphicChecksum()
 	}
@@ -651,6 +653,7 @@ func flushObjectMetadata(signer neofscrypto.Signer, meta dynamicObjectMetadata, 
 	header.SetPayloadChecksum(checksum.NewFromHash(checksum.SHA256, meta.checksum))
 
 	if meta.homomorphicChecksum != nil {
+		//nolint:staticcheck // still supported for clients
 		header.SetPayloadHomomorphicHash(checksum.NewFromHash(checksum.TillichZemor, meta.homomorphicChecksum))
 	}
 

--- a/object/slicer/slicer_test.go
+++ b/object/slicer/slicer_test.go
@@ -122,6 +122,7 @@ func networkInfoFromOpts(opts slicer.Options) (netmap.NetworkInfo, error) {
 	ni.SetRawNetworkParameter(string(testutil.RandByteSlice(10)), testutil.RandByteSlice(10))
 	ni.SetCurrentEpoch(opts.CurrentNeoFSEpoch())
 	ni.SetMaxObjectSize(opts.ObjectPayloadLimit())
+	//nolint:staticcheck // compatibility
 	if !opts.IsHomomorphicChecksumEnabled() {
 		ni.DisableHomomorphicHashing()
 	}
@@ -547,6 +548,7 @@ func checkStaticMetadata(tb testing.TB, header object.Object, in input) {
 
 	require.NoError(tb, header.CheckHeaderVerificationFields(), "verification fields must be correctly set in header")
 
+	//nolint:staticcheck // still supported for clients
 	_, ok := header.PayloadHomomorphicHash()
 	require.Equal(tb, in.withHomo, ok)
 }
@@ -652,6 +654,7 @@ func (x *chainCollector) handleOutgoingObject(headerOriginal object.Object, payl
 		hs: []hash.Hash{sha256.New()},
 	}
 
+	//nolint:staticcheck // still supported for clients
 	csHomo, ok := header.PayloadHomomorphicHash()
 	if ok {
 		pcs.cs = append(pcs.cs, csHomo)

--- a/object/test/generate.go
+++ b/object/test/generate.go
@@ -61,7 +61,7 @@ func generate(withParent bool) object.Object {
 	splitID := SplitID()
 	x.SetSplitID(&splitID)
 	x.SetPayloadChecksum(checksumtest.Checksum())
-	x.SetPayloadHomomorphicHash(checksumtest.Checksum())
+	x.SetPayloadHomomorphicHash(checksumtest.Checksum()) //nolint:staticcheck // such an object may be replicated
 
 	if withParent {
 		par := generate(false)

--- a/object/test/generate.go
+++ b/object/test/generate.go
@@ -61,7 +61,6 @@ func generate(withParent bool) object.Object {
 	splitID := SplitID()
 	x.SetSplitID(&splitID)
 	x.SetPayloadChecksum(checksumtest.Checksum())
-	x.SetPayloadHomomorphicHash(checksumtest.Checksum()) //nolint:staticcheck // such an object may be replicated
 
 	if withParent {
 		par := generate(false)

--- a/pool/object_test.go
+++ b/pool/object_test.go
@@ -440,7 +440,7 @@ func TestPool_ObjectHash(t *testing.T) {
 	hashOpts.WithBearerToken(bearertest.Token())
 	hashOpts.MarkLocal()
 	hashOpts.WithXHeaders("k1", "v1", "k2", "v2")
-	hashOpts.TillichZemorAlgo()
+	hashOpts.TillichZemorAlgo() //nolint:staticcheck // still supported for clients
 	hashOpts.SetRangeList(1, 2, 3, 4)
 	hashOpts.UseSalt([]byte("any_salt"))
 


### PR DESCRIPTION
*: deprecate Tillich-Zémor checksum

`checksum`: warnings to deprecated `NewTillichZemor` and it is impossible to
create TZ checksum from `NewFromData`.
`client`: warnings to deprecated `RangeHash` calls that request TZ hashing or
 `Search` calls with `FilterPayloadHomomorphicHash` filter.
`slicer`: warnings to constructors with homomorphic hashing enabled.
`object`: warnings to hash setter and getter.

Refs https://github.com/nspcc-dev/neofs-node/issues/3847.

Signed-off-by: Pavel Karpy <carpawell@nspcc.ru>