### PR TITLE
eacl: return "final" bit for the action

### DIFF
--- a/eacl/validator.go
+++ b/eacl/validator.go
@@ -22,10 +22,12 @@ func NewValidator() *Validator {
 // The action is calculated according to the application of
 // eACL table of rules to the request.
 //
-// Second return value is true iff the action was produced by a matching entry.
-//
-// If no matching table entry is found or some filters are missing,
-// ActionAllow is returned and the second return value is false.
+// Second return value is true if the action was produced by a matching entry
+// or it's the default action (which is [ActionAllow] to follow basic ACL).
+// It means the calculation is final and either not dependent on headers
+// or all required headers were successfully processed. If some filters
+// can't be processed because of missing headers [ActionAllow] is returned and
+// the second return value is false.
 //
 // Note that if some rule imposes requirements on the format of values (like
 // numeric), but they do not comply with it - such a rule does not match.
@@ -53,7 +55,7 @@ func (v *Validator) CalculateAction(unit *ValidationUnit) (Action, bool, error) 
 		}
 	}
 
-	return ActionAllow, false, nil
+	return ActionAllow, true, nil
 }
 
 // returns:

--- a/eacl/validator_test.go
+++ b/eacl/validator_test.go
@@ -14,7 +14,7 @@ import (
 func checkIgnoredAction(t *testing.T, expected Action, v *Validator, vu *ValidationUnit) {
 	action, ok, err := v.CalculateAction(vu)
 	require.NoError(t, err)
-	require.False(t, ok)
+	require.True(t, ok)
 	require.Equal(t, expected, action)
 }
 
@@ -28,7 +28,7 @@ func checkAction(t *testing.T, expected Action, v *Validator, vu *ValidationUnit
 func checkDefaultAction(t *testing.T, v *Validator, vu *ValidationUnit, msgAndArgs ...any) {
 	action, ok, err := v.CalculateAction(vu)
 	require.NoError(t, err)
-	require.False(t, ok, msgAndArgs)
+	require.True(t, ok, msgAndArgs)
 	require.Equal(t, ActionAllow, action, msgAndArgs...)
 }
 
@@ -353,7 +353,7 @@ func (h headers) HeadersOfType(ht FilterHeaderType) ([]Header, bool, error) {
 	case HeaderFromObject:
 		return h.obj, true, nil
 	default:
-		return nil, false, nil
+		return nil, true, nil
 	}
 }
 


### PR DESCRIPTION
Tune the semantics of the second return value, default action is perfectly fine if all rules were processed correctly. The only we really care about is missing headers and it's still the same, false is returned to signal that.