### PR TITLE
client,pool: drop response meta header callback

### DIFF
--- a/client/accounting.go
+++ b/client/accounting.go
@@ -80,17 +80,6 @@ func (c *Client) BalanceGet(ctx context.Context, prm PrmBalanceGet) (accounting.
 		return res, err
 	}
 
-	if c.prm.cbRespInfo != nil {
-		err = c.prm.cbRespInfo(ResponseMetaInfo{
-			key:   c.nodeKey,
-			epoch: resp.GetMetaHeader().GetEpoch(),
-		})
-		if err != nil {
-			err = fmt.Errorf("%w: %w", errResponseCallback, err)
-			return res, err
-		}
-	}
-
 	if err = apistatus.ToError(resp.GetMetaHeader().GetStatus()); err != nil {
 		return res, err
 	}

--- a/client/accounting_test.go
+++ b/client/accounting_test.go
@@ -228,12 +228,6 @@ func TestClient_BalanceGet(t *testing.T) {
 			return err
 		})
 	})
-	t.Run("response callback", func(t *testing.T) {
-		testUnaryResponseCallback(t, newTestGetBalanceServer, newDefaultAccountingService, func(c *Client) error {
-			_, err := c.BalanceGet(ctx, anyValidPrm)
-			return err
-		})
-	})
 	t.Run("exec statistics", func(t *testing.T) {
 		testStatistic(t, newTestGetBalanceServer, newDefaultAccountingService, stat.MethodBalanceGet,
 			nil,

--- a/client/client.go
+++ b/client/client.go
@@ -237,8 +237,6 @@ func (c *Client) sendStatistic(m stat.Method, dur time.Duration, err error) {
 type PrmInit struct {
 	signer neofscrypto.Signer
 
-	cbRespInfo func(ResponseMetaInfo) error
-
 	netMagic uint64 //nolint:unused // https://github.com/nspcc-dev/neofs-sdk-go/issues/671
 
 	statisticCallback stat.OperationCallback
@@ -256,12 +254,6 @@ func (x *PrmInit) SetSignMessageBufferSizes(size uint64) {
 // SetSignMessageBuffers sets buffers which are using in GRPC message signing process and helps to reduce memory allocations.
 func (x *PrmInit) SetSignMessageBuffers(buffers *sync.Pool) {
 	x.buffers = buffers
-}
-
-// SetResponseInfoCallback makes the Client to pass ResponseMetaInfo from each
-// NeoFS server response to f. Nil (default) means ignore response meta info.
-func (x *PrmInit) SetResponseInfoCallback(f func(ResponseMetaInfo) error) {
-	x.cbRespInfo = f
 }
 
 // SetStatisticCallback makes the Client to pass [stat.OperationCallback] for the external statistic.
@@ -357,11 +349,9 @@ func (x *PrmDial) setDialFunc(connFunc connFunc) {
 //
 // The streamMsgTimeout must not be negative. It defaults to 10s when zero.
 //
-// The respInterceptor is optional.
-//
 // Experimental: the function focuses on SN system needs and is not recommended
 // for use by regular apps. May be removed in future releases.
-func NewGRPC(_ context.Context, nodePub []byte, conn *grpc.ClientConn, signBufPool *sync.Pool, streamMsgTimeout time.Duration, respInterceptor func(pub []byte) error) (*Client, error) {
+func NewGRPC(_ context.Context, nodePub []byte, conn *grpc.ClientConn, signBufPool *sync.Pool, streamMsgTimeout time.Duration) (*Client, error) {
 	if streamMsgTimeout < 0 {
 		panic(fmt.Sprintf("negative stream message timeout %v", streamMsgTimeout))
 	}
@@ -387,9 +377,7 @@ func NewGRPC(_ context.Context, nodePub []byte, conn *grpc.ClientConn, signBufPo
 		streamTimeout: streamMsgTimeout,
 	}
 	c.setConn(conn)
-	if respInterceptor != nil {
-		c.prm.cbRespInfo = func(info ResponseMetaInfo) error { return respInterceptor(info.key) }
-	}
+
 	return c, nil
 }
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1252,49 +1252,6 @@ func testIncorrectUnaryRPCResponseFormat(t testing.TB, svcName, method string, o
 	require.Equal(t, codes.Internal, st.Code())
 }
 
-// asserts that given [Client] op correctly reports meta information received
-// from built test server when consuming the specified service. The op must be
-// executed with all the correct parameters.
-func testUnaryResponseCallback[SRV interface {
-	respondWithMeta(*protosession.ResponseMetaHeader)
-}](
-	t testing.TB,
-	newSrv func() SRV,
-	newSvc func(t testing.TB, srv any) testService,
-	op testedClientOp,
-) {
-	srv := newSrv()
-	srvEpoch := rand.Uint64()
-	srv.respondWithMeta(&protosession.ResponseMetaHeader{Epoch: srvEpoch})
-
-	var collected []ResponseMetaInfo
-	var handlerErr error
-	handler := func(meta ResponseMetaInfo) error {
-		collected = append(collected, meta)
-		return handlerErr
-	}
-	assert := func(expEpoch uint64, expPub []byte) {
-		require.Len(t, collected, 1)
-		require.Equal(t, expEpoch, collected[0].Epoch())
-		require.Equal(t, expPub, collected[0].ResponderKey())
-		collected = nil
-	}
-
-	c := newCustomClient(t, func(prm *PrmInit) { prm.SetResponseInfoCallback(handler) }, newSvc(t, srv))
-	// [Client.EndpointInfo] is always called to dial the server: this is also submitted
-	assert(testServerStateOnDial.epoch, testServerStateOnDial.pub)
-
-	err := op(c)
-	require.NoError(t, err)
-	assert(srvEpoch, testServerStateOnDial.pub)
-
-	handlerErr = errors.New("any response meta handler failure")
-	err = op(c)
-	require.ErrorContains(t, err, "response callback error")
-	require.ErrorIs(t, err, handlerErr)
-	assert(srvEpoch, testServerStateOnDial.pub)
-}
-
 // checks that the [Client] correctly keeps exec statistics of specified ops
 // performing communication with built test server. All operations must comply
 // with the tested service.
@@ -1402,18 +1359,18 @@ func TestNewGRPC(t *testing.T) {
 	pubKey := testServerStateOnDial.pub
 
 	t.Run("empty public key", func(t *testing.T) {
-		_, err := NewGRPC(ctx, []byte{}, conn, nil, 0, nil)
+		_, err := NewGRPC(ctx, []byte{}, conn, nil, 0)
 		require.EqualError(t, err, "empty public key")
-		_, err = NewGRPC(ctx, nil, conn, nil, 0, nil)
+		_, err = NewGRPC(ctx, nil, conn, nil, 0)
 		require.EqualError(t, err, "empty public key")
 	})
 	t.Run("negative stream message timeout", func(t *testing.T) {
 		require.PanicsWithValue(t, "negative stream message timeout -1ms", func() {
-			_, _ = NewGRPC(ctx, pubKey, conn, nil, -time.Millisecond, nil)
+			_, _ = NewGRPC(ctx, pubKey, conn, nil, -time.Millisecond)
 		})
 	})
 	t.Run("default buffer pool", func(t *testing.T) {
-		c, err := NewGRPC(ctx, pubKey, conn, nil, 0, nil)
+		c, err := NewGRPC(ctx, pubKey, conn, nil, 0)
 		require.NoError(t, err)
 		require.NotNil(t, c.buffers)
 		b := c.buffers.Get()
@@ -1421,25 +1378,15 @@ func TestNewGRPC(t *testing.T) {
 		require.Len(t, *b.(*[]byte), 4<<20)
 	})
 	t.Run("default stream message timeout", func(t *testing.T) {
-		c, err := NewGRPC(ctx, pubKey, conn, nil, 0, nil)
+		c, err := NewGRPC(ctx, pubKey, conn, nil, 0)
 		require.NoError(t, err)
 		require.Equal(t, 10*time.Second, c.streamTimeout)
-	})
-	t.Run("no response interceptor", func(t *testing.T) {
-		c, err := NewGRPC(ctx, pubKey, conn, nil, 0, nil)
-		require.NoError(t, err)
-		require.Nil(t, c.prm.cbRespInfo)
 	})
 
 	const anyStreamMsgTimeout = time.Minute
 	anySignBufferPool := &sync.Pool{New: func() any { b := []byte("Hello, world!"); return &b }}
-	var caughtPub []byte
-	anyInterceptorErr := errors.New("any interceptor error")
 
-	c, err := NewGRPC(ctx, pubKey, conn, anySignBufferPool, anyStreamMsgTimeout, func(pub []byte) error {
-		caughtPub = pub
-		return anyInterceptorErr
-	})
+	c, err := NewGRPC(ctx, pubKey, conn, anySignBufferPool, anyStreamMsgTimeout)
 	require.NoError(t, err)
 	require.NotNil(t, c)
 
@@ -1456,10 +1403,4 @@ func TestNewGRPC(t *testing.T) {
 	require.Equal(t, anySignBufferPool, c.buffers)
 
 	require.Equal(t, anyStreamMsgTimeout, c.streamTimeout)
-
-	require.NotNil(t, c.prm.cbRespInfo)
-	pub := []byte("any public key")
-	err = c.prm.cbRespInfo(ResponseMetaInfo{key: pub})
-	require.ErrorIs(t, err, anyInterceptorErr)
-	require.Equal(t, pub, caughtPub)
 }

--- a/client/container.go
+++ b/client/container.go
@@ -209,17 +209,6 @@ func (c *Client) ContainerPut(ctx context.Context, cont container.Container, sig
 		return res, err
 	}
 
-	if c.prm.cbRespInfo != nil {
-		err = c.prm.cbRespInfo(ResponseMetaInfo{
-			key:   c.nodeKey,
-			epoch: resp.GetMetaHeader().GetEpoch(),
-		})
-		if err != nil {
-			err = fmt.Errorf("%w: %w", errResponseCallback, err)
-			return res, err
-		}
-	}
-
 	var statusError error
 	if err = apistatus.ToError(resp.GetMetaHeader().GetStatus()); err != nil {
 		if !errors.Is(err, apistatus.ErrContainerAwaitTimeout) {
@@ -292,17 +281,6 @@ func (c *Client) ContainerGet(ctx context.Context, id cid.ID, prm PrmContainerGe
 		return res, err
 	}
 
-	if c.prm.cbRespInfo != nil {
-		err = c.prm.cbRespInfo(ResponseMetaInfo{
-			key:   c.nodeKey,
-			epoch: resp.GetMetaHeader().GetEpoch(),
-		})
-		if err != nil {
-			err = fmt.Errorf("%w: %w", errResponseCallback, err)
-			return res, err
-		}
-	}
-
 	if err = apistatus.ToError(resp.GetMetaHeader().GetStatus()); err != nil {
 		return res, err
 	}
@@ -366,17 +344,6 @@ func (c *Client) ContainerList(ctx context.Context, ownerID user.ID, prm PrmCont
 	if err != nil {
 		err = rpcErr(err)
 		return nil, err
-	}
-
-	if c.prm.cbRespInfo != nil {
-		err = c.prm.cbRespInfo(ResponseMetaInfo{
-			key:   c.nodeKey,
-			epoch: resp.GetMetaHeader().GetEpoch(),
-		})
-		if err != nil {
-			err = fmt.Errorf("%w: %w", errResponseCallback, err)
-			return nil, err
-		}
 	}
 
 	if err = apistatus.ToError(resp.GetMetaHeader().GetStatus()); err != nil {
@@ -532,17 +499,6 @@ func (c *Client) ContainerDelete(ctx context.Context, id cid.ID, signer neofscry
 		return err
 	}
 
-	if c.prm.cbRespInfo != nil {
-		err = c.prm.cbRespInfo(ResponseMetaInfo{
-			key:   c.nodeKey,
-			epoch: resp.GetMetaHeader().GetEpoch(),
-		})
-		if err != nil {
-			err = fmt.Errorf("%w: %w", errResponseCallback, err)
-			return err
-		}
-	}
-
 	err = apistatus.ToError(resp.GetMetaHeader().GetStatus())
 	return err
 }
@@ -593,17 +549,6 @@ func (c *Client) ContainerEACL(ctx context.Context, id cid.ID, prm PrmContainerE
 	if err != nil {
 		err = rpcErr(err)
 		return res, err
-	}
-
-	if c.prm.cbRespInfo != nil {
-		err = c.prm.cbRespInfo(ResponseMetaInfo{
-			key:   c.nodeKey,
-			epoch: resp.GetMetaHeader().GetEpoch(),
-		})
-		if err != nil {
-			err = fmt.Errorf("%w: %w", errResponseCallback, err)
-			return res, err
-		}
 	}
 
 	if err = apistatus.ToError(resp.GetMetaHeader().GetStatus()); err != nil {
@@ -764,17 +709,6 @@ func (c *Client) ContainerSetEACL(ctx context.Context, table eacl.Table, signer 
 	if err != nil {
 		err = rpcErr(err)
 		return err
-	}
-
-	if c.prm.cbRespInfo != nil {
-		err = c.prm.cbRespInfo(ResponseMetaInfo{
-			key:   c.nodeKey,
-			epoch: resp.GetMetaHeader().GetEpoch(),
-		})
-		if err != nil {
-			err = fmt.Errorf("%w: %w", errResponseCallback, err)
-			return err
-		}
 	}
 
 	err = apistatus.ToError(resp.GetMetaHeader().GetStatus())

--- a/client/container_test.go
+++ b/client/container_test.go
@@ -988,12 +988,6 @@ func TestClient_ContainerPut(t *testing.T) {
 			return err
 		})
 	})
-	t.Run("response callback", func(t *testing.T) {
-		testUnaryResponseCallback(t, newTestPutContainerServer, newDefaultContainerService, func(c *Client) error {
-			_, err := c.ContainerPut(ctx, anyValidContainer, anyValidSigner, anyValidOpts)
-			return err
-		})
-	})
 	t.Run("exec statistics", func(t *testing.T) {
 		testStatistic(t, newTestPutContainerServer, newDefaultContainerService, stat.MethodContainerPut,
 			[]testedClientOp{func(c *Client) error {
@@ -1213,12 +1207,6 @@ func TestClient_ContainerGet(t *testing.T) {
 			return err
 		})
 	})
-	t.Run("response callback", func(t *testing.T) {
-		testUnaryResponseCallback(t, newTestGetContainerServer, newDefaultContainerService, func(c *Client) error {
-			_, err := c.ContainerGet(ctx, anyID, anyValidOpts)
-			return err
-		})
-	})
 	t.Run("exec statistics", func(t *testing.T) {
 		testStatistic(t, newTestGetContainerServer, newDefaultContainerService, stat.MethodContainerGet,
 			nil, nil, func(c *Client) error {
@@ -1357,12 +1345,6 @@ func TestClient_ContainerList(t *testing.T) {
 	})
 	t.Run("transport failure", func(t *testing.T) {
 		testTransportFailure(t, newTestListContainersServer, newTestContainerClient, func(c *Client) error {
-			_, err := c.ContainerList(ctx, anyUser, anyValidOpts)
-			return err
-		})
-	})
-	t.Run("response callback", func(t *testing.T) {
-		testUnaryResponseCallback(t, newTestListContainersServer, newDefaultContainerService, func(c *Client) error {
 			_, err := c.ContainerList(ctx, anyUser, anyValidOpts)
 			return err
 		})
@@ -1550,11 +1532,6 @@ func TestClient_ContainerDelete(t *testing.T) {
 			return c.ContainerDelete(ctx, anyID, anyValidSigner, anyValidOpts)
 		})
 	})
-	t.Run("response callback", func(t *testing.T) {
-		testUnaryResponseCallback(t, newTestDeleteContainerServer, newDefaultContainerService, func(c *Client) error {
-			return c.ContainerDelete(ctx, anyID, anyValidSigner, anyValidOpts)
-		})
-	})
 	t.Run("exec statistics", func(t *testing.T) {
 		testStatistic(t, newTestDeleteContainerServer, newDefaultContainerService, stat.MethodContainerDelete,
 			[]testedClientOp{func(c *Client) error {
@@ -1717,12 +1694,6 @@ func TestClient_ContainerEACL(t *testing.T) {
 	})
 	t.Run("transport failure", func(t *testing.T) {
 		testTransportFailure(t, newTestGetEACLServer, newTestContainerClient, func(c *Client) error {
-			_, err := c.ContainerEACL(ctx, anyID, anyValidOpts)
-			return err
-		})
-	})
-	t.Run("response callback", func(t *testing.T) {
-		testUnaryResponseCallback(t, newTestGetEACLServer, newDefaultContainerService, func(c *Client) error {
 			_, err := c.ContainerEACL(ctx, anyID, anyValidOpts)
 			return err
 		})
@@ -1893,11 +1864,6 @@ func TestClient_ContainerSetEACL(t *testing.T) {
 	})
 	t.Run("transport failure", func(t *testing.T) {
 		testTransportFailure(t, newTestSetEACLServer, newTestContainerClient, func(c *Client) error {
-			return c.ContainerSetEACL(ctx, anyValidEACL, anyValidSigner, anyValidOpts)
-		})
-	})
-	t.Run("response callback", func(t *testing.T) {
-		testUnaryResponseCallback(t, newTestSetEACLServer, newDefaultContainerService, func(c *Client) error {
 			return c.ContainerSetEACL(ctx, anyValidEACL, anyValidSigner, anyValidOpts)
 		})
 	})

--- a/client/errors.go
+++ b/client/errors.go
@@ -37,8 +37,7 @@ var (
 	// ErrMissingResponseField is returned when required field is not exists in NeoFS api response.
 	ErrMissingResponseField MissingResponseFieldErr
 
-	errSignRequest      = errors.New("sign request")
-	errResponseCallback = errors.New("response callback error")
+	errSignRequest = errors.New("sign request")
 	// errSessionTokenBothVersionsSet is returned when both versions of session token are set.
 	errSessionTokenBothVersionsSet = errors.New("cannot use both versions of session token")
 )

--- a/client/netmap.go
+++ b/client/netmap.go
@@ -92,17 +92,6 @@ func (c *Client) EndpointInfo(ctx context.Context, prm PrmEndpointInfo) (*ResEnd
 		return nil, err
 	}
 
-	if c.prm.cbRespInfo != nil {
-		err = c.prm.cbRespInfo(ResponseMetaInfo{
-			key:   resp.GetBody().GetNodeInfo().GetPublicKey(),
-			epoch: resp.GetMetaHeader().GetEpoch(),
-		})
-		if err != nil {
-			err = fmt.Errorf("%w: %w", errResponseCallback, err)
-			return nil, err
-		}
-	}
-
 	if err = apistatus.ToError(resp.GetMetaHeader().GetStatus()); err != nil {
 		return nil, err
 	}
@@ -187,17 +176,6 @@ func (c *Client) NetworkInfo(ctx context.Context, prm PrmNetworkInfo) (netmap.Ne
 	if err != nil {
 		err = rpcErr(err)
 		return res, err
-	}
-
-	if c.prm.cbRespInfo != nil {
-		err = c.prm.cbRespInfo(ResponseMetaInfo{
-			key:   c.nodeKey,
-			epoch: resp.GetMetaHeader().GetEpoch(),
-		})
-		if err != nil {
-			err = fmt.Errorf("%w: %w", errResponseCallback, err)
-			return res, err
-		}
 	}
 
 	if err = apistatus.ToError(resp.GetMetaHeader().GetStatus()); err != nil {

--- a/client/netmap_test.go
+++ b/client/netmap_test.go
@@ -502,14 +502,6 @@ func TestClient_EndpointInfo(t *testing.T) {
 			return err
 		})
 	})
-	t.Run("response callback", func(t *testing.T) {
-		srv := newTestGetNodeInfoServer()
-		srv.respondWithNodePublicKey(testServerStateOnDial.pub)
-		testUnaryResponseCallback(t, func() *testGetNodeInfoServer { return srv }, newDefaultNetmapServiceDesc, func(c *Client) error {
-			_, err := c.EndpointInfo(ctx, anyValidOpts)
-			return err
-		})
-	})
 	t.Run("exec statistics", func(t *testing.T) {
 		testStatistic(t, newTestGetNodeInfoServer, newDefaultNetmapServiceDesc, stat.MethodEndpointInfo,
 			nil, nil, func(c *Client) error {
@@ -627,13 +619,6 @@ func TestClient_NetMapSnapshot(t *testing.T) {
 	t.Run("transport failure", func(t *testing.T) {
 		t.Skip("https://github.com/nspcc-dev/neofs-sdk-go/issues/654")
 		testTransportFailure(t, newTestNetmapSnapshotServer, newTestNetmapClient, func(c *Client) error {
-			_, err := c.NetMapSnapshot(ctx, anyValidOpts)
-			return err
-		})
-	})
-	t.Run("response callback", func(t *testing.T) {
-		t.Skip("https://github.com/nspcc-dev/neofs-sdk-go/issues/654")
-		testUnaryResponseCallback(t, newTestNetmapSnapshotServer, newDefaultNetmapServiceDesc, func(c *Client) error {
 			_, err := c.NetMapSnapshot(ctx, anyValidOpts)
 			return err
 		})
@@ -762,12 +747,6 @@ func TestClient_NetworkInfo(t *testing.T) {
 	})
 	t.Run("transport failure", func(t *testing.T) {
 		testTransportFailure(t, newTestNetworkInfoServer, newTestNetmapClient, func(c *Client) error {
-			_, err := c.NetworkInfo(ctx, anyValidOpts)
-			return err
-		})
-	})
-	t.Run("response callback", func(t *testing.T) {
-		testUnaryResponseCallback(t, newTestNetworkInfoServer, newDefaultNetmapServiceDesc, func(c *Client) error {
 			_, err := c.NetworkInfo(ctx, anyValidOpts)
 			return err
 		})

--- a/client/object_delete_test.go
+++ b/client/object_delete_test.go
@@ -308,13 +308,6 @@ func TestClient_ObjectDelete(t *testing.T) {
 			return err
 		})
 	})
-	t.Run("response callback", func(t *testing.T) {
-		t.Skip("https://github.com/nspcc-dev/neofs-sdk-go/issues/654")
-		testUnaryResponseCallback(t, newTestDeleteObjectServer, newDefaultObjectService, func(c *Client) error {
-			_, err := c.ObjectDelete(ctx, anyCID, anyOID, anyValidSigner, anyValidOpts)
-			return err
-		})
-	})
 	t.Run("exec statistics", func(t *testing.T) {
 		testStatistic(t, newTestDeleteObjectServer, newDefaultObjectService, stat.MethodObjectDelete,
 			[]testedClientOp{func(c *Client) error {

--- a/client/object_get_test.go
+++ b/client/object_get_test.go
@@ -815,13 +815,6 @@ func TestClient_ObjectHead(t *testing.T) {
 			return err
 		})
 	})
-	t.Run("response callback", func(t *testing.T) {
-		t.Skip("https://github.com/nspcc-dev/neofs-sdk-go/issues/654")
-		testUnaryResponseCallback(t, newTestHeadObjectServer, newDefaultObjectService, func(c *Client) error {
-			_, err := c.ObjectHead(ctx, anyCID, anyOID, anyValidSigner, anyValidOpts)
-			return err
-		})
-	})
 	t.Run("exec statistics", func(t *testing.T) {
 		testStatistic(t, newTestHeadObjectServer, newDefaultObjectService, stat.MethodObjectHead,
 			[]testedClientOp{func(c *Client) error {
@@ -1480,10 +1473,6 @@ func TestClient_ObjectGetInit(t *testing.T) {
 			require.Equal(t, len(chunk), n)
 			require.EqualError(t, err, "payload size overflow")
 		})
-	})
-	t.Run("response callback", func(t *testing.T) {
-		t.Skip("https://github.com/nspcc-dev/neofs-sdk-go/issues/653")
-		// TODO: implement
 	})
 	t.Run("writer to", func(t *testing.T) {
 		t.Run("uses raw stream buffers", func(t *testing.T) {
@@ -2197,10 +2186,6 @@ func TestClient_ObjectRangeInit(t *testing.T) {
 			require.Equal(t, len(chunk), n)
 			require.EqualError(t, err, "payload range size overflow")
 		})
-	})
-	t.Run("response callback", func(t *testing.T) {
-		t.Skip("https://github.com/nspcc-dev/neofs-sdk-go/issues/653")
-		// TODO: implement
 	})
 	t.Run("writer to", func(t *testing.T) {
 		t.Run("continues from tail payload", func(t *testing.T) {

--- a/client/object_hash_test.go
+++ b/client/object_hash_test.go
@@ -329,13 +329,6 @@ func TestClient_ObjectHash(t *testing.T) {
 			return err
 		})
 	})
-	t.Run("response callback", func(t *testing.T) {
-		t.Skip("https://github.com/nspcc-dev/neofs-sdk-go/issues/653")
-		testUnaryResponseCallback(t, newTestHashObjectServer, newDefaultObjectService, func(c *Client) error {
-			_, err := c.ObjectHash(ctx, anyCID, anyOID, anyValidSigner, anyValidOpts)
-			return err
-		})
-	})
 	t.Run("exec statistics", func(t *testing.T) {
 		testStatistic(t, newTestHashObjectServer, newDefaultObjectService, stat.MethodObjectHash,
 			[]testedClientOp{func(c *Client) error {

--- a/client/object_put_test.go
+++ b/client/object_put_test.go
@@ -680,10 +680,6 @@ func TestClient_ObjectPut(t *testing.T) {
 			}
 		})
 	})
-	t.Run("response callback", func(t *testing.T) {
-		t.Skip("https://github.com/nspcc-dev/neofs-sdk-go/issues/653")
-		// TODO: implement
-	})
 	t.Run("exec statistics", func(t *testing.T) {
 		type collectedItem struct {
 			pub      []byte

--- a/client/object_search.go
+++ b/client/object_search.go
@@ -206,17 +206,6 @@ func (c *Client) SearchObjects(ctx context.Context, cnr cid.ID, filters object.S
 		return nil, "", err
 	}
 
-	if c.prm.cbRespInfo != nil {
-		err = c.prm.cbRespInfo(ResponseMetaInfo{
-			key:   c.nodeKey,
-			epoch: resp.GetMetaHeader().GetEpoch(),
-		})
-		if err != nil {
-			err = fmt.Errorf("%w: %w", errResponseCallback, err)
-			return nil, "", err
-		}
-	}
-
 	var statusError error
 	if err = apistatus.ToError(resp.GetMetaHeader().GetStatus()); err != nil {
 		if !errors.Is(err, apistatus.ErrIncomplete) {

--- a/client/object_search_test.go
+++ b/client/object_search_test.go
@@ -540,10 +540,6 @@ func TestClient_ObjectSearch(t *testing.T) {
 			require.Contains(t, st.Message(), " vs. 4194304)")
 		})
 	})
-	t.Run("response callback", func(t *testing.T) {
-		t.Skip("https://github.com/nspcc-dev/neofs-sdk-go/issues/653")
-		// TODO: implement
-	})
 	t.Run("exec statistics", func(t *testing.T) {
 		type collectedItem struct {
 			pub      []byte
@@ -1144,12 +1140,6 @@ func TestClient_SearchObjects(t *testing.T) {
 	})
 	t.Run("transport failure", func(t *testing.T) {
 		testTransportFailure(t, newTestSearchObjectsV2Server, newTestObjectClient, func(c *Client) error {
-			_, _, err := c.SearchObjects(ctx, anyCID, anyValidFilters, anyValidAttrs, anyRequestCursor, anyValidSigner, anyValidOpts)
-			return err
-		})
-	})
-	t.Run("response callback", func(t *testing.T) {
-		testUnaryResponseCallback(t, newTestSearchObjectsV2Server, newDefaultObjectService, func(c *Client) error {
 			_, _, err := c.SearchObjects(ctx, anyCID, anyValidFilters, anyValidAttrs, anyRequestCursor, anyValidSigner, anyValidOpts)
 			return err
 		})

--- a/client/reputation.go
+++ b/client/reputation.go
@@ -81,17 +81,6 @@ func (c *Client) AnnounceLocalTrust(ctx context.Context, epoch uint64, trusts []
 		return err
 	}
 
-	if c.prm.cbRespInfo != nil {
-		err = c.prm.cbRespInfo(ResponseMetaInfo{
-			key:   c.nodeKey,
-			epoch: resp.GetMetaHeader().GetEpoch(),
-		})
-		if err != nil {
-			err = fmt.Errorf("%w: %w", errResponseCallback, err)
-			return err
-		}
-	}
-
 	err = apistatus.ToError(resp.GetMetaHeader().GetStatus())
 	return err
 }
@@ -161,17 +150,6 @@ func (c *Client) AnnounceIntermediateTrust(ctx context.Context, epoch uint64, tr
 	if err != nil {
 		err = rpcErr(err)
 		return err
-	}
-
-	if c.prm.cbRespInfo != nil {
-		err = c.prm.cbRespInfo(ResponseMetaInfo{
-			key:   c.nodeKey,
-			epoch: resp.GetMetaHeader().GetEpoch(),
-		})
-		if err != nil {
-			err = fmt.Errorf("%w: %w", errResponseCallback, err)
-			return err
-		}
 	}
 
 	err = apistatus.ToError(resp.GetMetaHeader().GetStatus())

--- a/client/reputation_test.go
+++ b/client/reputation_test.go
@@ -339,11 +339,6 @@ func TestClient_AnnounceIntermediateTrust(t *testing.T) {
 			return c.AnnounceIntermediateTrust(ctx, anyValidEpoch, anyValidTrust, anyValidOpts)
 		})
 	})
-	t.Run("response callback", func(t *testing.T) {
-		testUnaryResponseCallback(t, newTestAnnounceIntermediateReputationServer, newDefaultReputationServiceDesc, func(c *Client) error {
-			return c.AnnounceIntermediateTrust(ctx, anyValidEpoch, anyValidTrust, anyValidOpts)
-		})
-	})
 	t.Run("exec statistics", func(t *testing.T) {
 		testStatistic(t, newTestAnnounceIntermediateReputationServer, newDefaultReputationServiceDesc, stat.MethodAnnounceIntermediateTrust,
 			nil, []testedClientOp{func(c *Client) error {
@@ -449,11 +444,6 @@ func TestClient_AnnounceLocalTrust(t *testing.T) {
 	})
 	t.Run("transport failure", func(t *testing.T) {
 		testTransportFailure(t, newTestAnnounceLocalTrustServer, newTestReputationClient, func(c *Client) error {
-			return c.AnnounceLocalTrust(ctx, anyValidEpoch, anyValidTrusts, anyValidOpts)
-		})
-	})
-	t.Run("response callback", func(t *testing.T) {
-		testUnaryResponseCallback(t, newTestAnnounceLocalTrustServer, newDefaultReputationServiceDesc, func(c *Client) error {
 			return c.AnnounceLocalTrust(ctx, anyValidEpoch, anyValidTrusts, anyValidOpts)
 		})
 	})

--- a/client/session.go
+++ b/client/session.go
@@ -111,17 +111,6 @@ func (c *Client) SessionCreate(ctx context.Context, signer user.Signer, prm PrmS
 		return nil, err
 	}
 
-	if c.prm.cbRespInfo != nil {
-		err = c.prm.cbRespInfo(ResponseMetaInfo{
-			key:   c.nodeKey,
-			epoch: resp.GetMetaHeader().GetEpoch(),
-		})
-		if err != nil {
-			err = fmt.Errorf("%w: %w", errResponseCallback, err)
-			return nil, err
-		}
-	}
-
 	if err = apistatus.ToError(resp.GetMetaHeader().GetStatus()); err != nil {
 		return nil, err
 	}

--- a/client/session_test.go
+++ b/client/session_test.go
@@ -250,12 +250,6 @@ func TestClient_SessionCreate(t *testing.T) {
 			return err
 		})
 	})
-	t.Run("response callback", func(t *testing.T) {
-		testUnaryResponseCallback(t, newTestCreateSessionInfoServer, newDefaultSessionServiceDesc, func(c *Client) error {
-			_, err := c.SessionCreate(ctx, anyUsr, anyValidOpts)
-			return err
-		})
-	})
 	t.Run("exec statistics", func(t *testing.T) {
 		testStatistic(t, newTestCreateSessionInfoServer, newDefaultSessionServiceDesc, stat.MethodSessionCreate,
 			[]testedClientOp{

--- a/pool/cache.go
+++ b/pool/cache.go
@@ -94,13 +94,6 @@ func (c *sessionCache) DeleteByPrefix(prefix string) {
 	}
 }
 
-func (c *sessionCache) updateEpoch(newEpoch uint64) {
-	epoch := atomic.LoadUint64(&c.currentEpoch)
-	if newEpoch > epoch {
-		atomic.StoreUint64(&c.currentEpoch, newEpoch)
-	}
-}
-
 // Purge removes all session keys.
 func (c *sessionCache) Purge() {
 	c.cache.Purge()

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -165,8 +165,6 @@ type clientWrapper struct {
 	statisticCallback stat.OperationCallback
 
 	nodeSessionCache *sessionCache
-
-	epoch atomic.Uint64
 }
 
 // wrapperPrm is params to create clientWrapper.
@@ -178,7 +176,6 @@ type wrapperPrm struct {
 	singleNode               bool
 	errorThreshold           uint32
 	errorThresholdWindowSize time.Duration
-	responseInfoCallback     func(sdkClient.ResponseMetaInfo) error
 	statisticCallback        stat.OperationCallback
 	buffers                  *sync.Pool
 	nodeSessionCacheSize     int
@@ -187,7 +184,6 @@ type wrapperPrm struct {
 // getNewClient returns a new [sdkClient.Client] instance using internal parameters.
 func (x *wrapperPrm) getNewClient(statisticCallback stat.OperationCallback) (*sdkClient.Client, error) {
 	var prmInit sdkClient.PrmInit
-	prmInit.SetResponseInfoCallback(x.responseInfoCallback)
 	prmInit.SetStatisticCallback(statisticCallback)
 	prmInit.SetSignMessageBuffers(x.buffers)
 
@@ -215,21 +211,6 @@ func newWrapper(prm wrapperPrm) (*clientWrapper, error) {
 		res.clientStatusMonitor = newNoopClientStatusMonitor()
 	} else {
 		res.clientStatusMonitor = newClientStatusMonitor(prm.errorThreshold, prm.errorThresholdWindowSize)
-	}
-
-	oldCallBack := prm.responseInfoCallback
-	prm.responseInfoCallback = func(info sdkClient.ResponseMetaInfo) error {
-		newEpoch := info.Epoch()
-		if newEpoch > res.epoch.Load() {
-			res.epoch.Store(newEpoch)
-			cache.updateEpoch(newEpoch)
-		}
-
-		if oldCallBack != nil {
-			return oldCallBack(info)
-		}
-
-		return nil
 	}
 
 	res.prm = prm
@@ -845,13 +826,9 @@ func fillDefaultInitParams(params *InitParameters, cache *sessionCache, statisti
 				singleNode:               len(params.nodeParams) == 1,
 				errorThreshold:           params.errorThreshold,
 				errorThresholdWindowSize: params.errorThresholdWindowSize,
-				responseInfoCallback: func(info sdkClient.ResponseMetaInfo) error {
-					cache.updateEpoch(info.Epoch())
-					return nil
-				},
-				statisticCallback:    statisticCallback,
-				buffers:              buffers,
-				nodeSessionCacheSize: params.nodeSessionCacheSize,
+				statisticCallback:        statisticCallback,
+				buffers:                  buffers,
+				nodeSessionCacheSize:     params.nodeSessionCacheSize,
 			}
 			return newWrapper(prm)
 		})


### PR DESCRIPTION
The only found usage is the Pool itself: it only reads an epoch, and stores it atomically, and that is all, there is no other usage for this atomic. Also, current node implementation does not provide actual epoch in any method, so it cannot be cached in practice. It is also essentially closes #654. Response side's key (as it was documented) was also misused starting from #717. Once response information is required, it can be returned in a more conscious form, currently it is buggy.